### PR TITLE
Correct PV requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Use the Web UI (Config flow) to add the "go-eCharger" integration. You have to k
 
 ### Setable only PV-surplus entities
 
-This feature requires firmware 0.55 or newer.
+This feature requires firmware 0.55.6 or newer.
 
 | Key | Friendly name | Category | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ------------------- | --------- | ------------------ |


### PR DESCRIPTION
To use PV surplus charging, you need at least firmware version 0.55.6 (beta) or newer.