### PR TITLE
remove required serial number from topic configuration

### DIFF
--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from .const import (
     ATTR_KEY,
-    ATTR_SERIAL_NUMBER,
+    ATTR_TOPIC,
     ATTR_VALUE,
     DEFAULT_TOPIC_PREFIX,
     DOMAIN,
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
     {
-        vol.Required(ATTR_SERIAL_NUMBER): cv.string,
+        vol.Required(ATTR_TOPIC): cv.string,
         vol.Required(ATTR_KEY): cv.string,
         vol.Required(ATTR_VALUE): cv.string,
     }
@@ -58,10 +58,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     @callback
     async def set_config_key_service(call: ServiceCall) -> None:
-        serial_number = call.data.get("serial_number")
+        topic = call.data.get(ATTR_TOPIC)
         key = call.data.get("key")
-        # @FIXME: Retrieve the topic_prefix from config_entry
-        topic = f"{DEFAULT_TOPIC_PREFIX}/{serial_number}/{key}/set"
+        topic = f"{topic}/{key}/set"
         value = call.data.get("value")
 
         if not value.isnumeric():

--- a/custom_components/goecharger_mqtt/const.py
+++ b/custom_components/goecharger_mqtt/const.py
@@ -2,14 +2,13 @@
 
 DOMAIN = "goecharger_mqtt"
 
-ATTR_SERIAL_NUMBER = "serial_number"
+ATTR_TOPIC = "serial_number"
 ATTR_KEY = "key"
 ATTR_VALUE = "value"
 
-CONF_SERIAL_NUMBER = "serial_number"
-CONF_TOPIC_PREFIX = "topic_prefix"
+CONF_TOPIC = "topic"
 
-DEFAULT_TOPIC_PREFIX = "/go-eCharger"
+DEFAULT_TOPIC_PREFIX = "go-eCharger/"
 
 DEVICE_INFO_MANUFACTURER = "go-e"
 DEVICE_INFO_MODEL = "go-eCharger HOME"

--- a/custom_components/goecharger_mqtt/entity.py
+++ b/custom_components/goecharger_mqtt/entity.py
@@ -4,8 +4,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.util import slugify
 
 from .const import (
-    CONF_SERIAL_NUMBER,
-    CONF_TOPIC_PREFIX,
+    CONF_TOPIC,
     DEVICE_INFO_MANUFACTURER,
     DEVICE_INFO_MODEL,
     DOMAIN,
@@ -22,19 +21,18 @@ class GoEChargerEntity(Entity):
         description: GoEChargerEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        topic_prefix = config_entry.data[CONF_TOPIC_PREFIX]
-        serial_number = config_entry.data[CONF_SERIAL_NUMBER]
+        topic = config_entry.data[CONF_TOPIC]
 
-        self._topic = f"{topic_prefix}/{serial_number}/{description.key}"
+        self._topic = f"{topic}/{description.key}"
 
         slug = slugify(self._topic.replace("/", "_"))
         self.entity_id = f"{description.domain}.{slug}"
 
         self._attr_unique_id = "-".join(
-            [serial_number, description.domain, description.key, description.attribute]
+            [topic, description.domain, description.key, description.attribute]
         )
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, serial_number)},
+            identifiers={(DOMAIN, topic)},
             name=config_entry.title,
             manufacturer=DEVICE_INFO_MANUFACTURER,
             model=DEVICE_INFO_MODEL,

--- a/custom_components/goecharger_mqtt/strings.json
+++ b/custom_components/goecharger_mqtt/strings.json
@@ -8,8 +8,7 @@
       "user": {
         "description": "[%key:common::config_flow::description%]",
         "data": {
-          "serial_number": "[%key:common::config_flow::data::serial_number%]",
-          "topic_prefix": "[%key:common::config_flow::data::topic_prefix%]"
+          "topic": "[%key:common::config_flow::data::topic%]"
         }
       }
     },

--- a/custom_components/goecharger_mqtt/translations/en.json
+++ b/custom_components/goecharger_mqtt/translations/en.json
@@ -14,10 +14,9 @@
                 "description": "Do you want to setup {name}?"
             },
             "user": {
-                "description": "Please provide the serial number of your device",
+                "description": "Please provide the MQTT topic of your device",
                 "data": {
-                    "serial_number": "Serial number",
-                    "topic_prefix": "Base topic"
+                    "topic": "MQTT topic"
                 }
             }
         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -25,15 +25,13 @@ async def test_form(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"serial_number": "012345", "topic_prefix": "/go-eCharger"},
+            {"topic": "/go-eCharger/012345"},
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "go-eCharger 012345"
-    assert result2["data"] == {
-        "serial_number": "012345",
-        "topic_prefix": "/go-eCharger",
+    assert result2["data"] == {"topic": "/go-eCharger/012345"
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -50,7 +48,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"serial_number": "012345", "topic_prefix": "/go-eCharger"},
+            {"topic": "/go-eCharger/012345"},
         )
 
     assert result2["type"] == RESULT_TYPE_FORM


### PR DESCRIPTION
Removes the serial number input and expects it as part of the topic instead. (#138)
Set the device name as the basename of the topic. Use the whole topic as the device id. 

Also removes the leading slash as in https://github.com/syssi/homeassistant-goecharger-mqtt/pull/128