### PR TITLE
Fix: Retrieve topic_prefix from config_entry for set_config_key service

### DIFF
--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -15,6 +15,8 @@ from .const import (
     ATTR_KEY,
     ATTR_SERIAL_NUMBER,
     ATTR_VALUE,
+    CONF_SERIAL_NUMBER,
+    CONF_TOPIC_PREFIX,
     DEFAULT_TOPIC_PREFIX,
     DOMAIN,
 )
@@ -42,15 +44,24 @@ SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up go-eCharger (MQTT) from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    
+    # Store config entries for service access
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][entry.data[CONF_SERIAL_NUMBER]] = entry
+    
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
+    
+    # Remove config entry from storage
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.data[CONF_SERIAL_NUMBER], None)
+    
     return unload_ok
 
 
@@ -59,12 +70,25 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     @callback
     async def set_config_key_service(call: ServiceCall) -> None:
-        serial_number = call.data.get("serial_number")
-        key = call.data.get("key")
-        # @FIXME: Retrieve the topic_prefix from config_entry
-        topic = f"{DEFAULT_TOPIC_PREFIX}/{serial_number}/{key}/set"
-        value = call.data.get("value")
-
+        serial_number = call.data.get(ATTR_SERIAL_NUMBER)
+        key = call.data.get(ATTR_KEY)
+        value = call.data.get(ATTR_VALUE)
+        
+        # Retrieve the topic_prefix from config_entry
+        topic_prefix = DEFAULT_TOPIC_PREFIX
+        if DOMAIN in hass.data and serial_number in hass.data[DOMAIN]:
+            entry = hass.data[DOMAIN][serial_number]
+            topic_prefix = entry.data.get(CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX)
+        else:
+            _LOGGER.warning(
+                "No config entry found for serial number %s, using default topic prefix %s",
+                serial_number,
+                DEFAULT_TOPIC_PREFIX,
+            )
+        
+        topic = f"{topic_prefix}/{serial_number}/{key}/set"
+        
+        # Handle value formatting
         if not value.isnumeric():
             if value in ["true", "True"]:
                 value = "true"
@@ -72,7 +96,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 value = "false"
             else:
                 value = f'"{value}"'
-
+        
+        _LOGGER.debug(
+            "Publishing to topic %s with value %s (serial: %s, key: %s)",
+            topic,
+            value,
+            serial_number,
+            key,
+        )
+        
         await mqtt.async_publish(hass, topic, value)
 
     hass.services.async_register(


### PR DESCRIPTION
Fixes #159

## Problem
The `set_config_key` service was using the hardcoded `DEFAULT_TOPIC_PREFIX` instead of reading the actual `topic_prefix` from the config entry. This caused the service to fail when the user's configured `topic_prefix` differed from the default value.

After version 0.24, the `DEFAULT_TOPIC_PREFIX` was changed from `/go-eCharger` to `go-eCharger` (without leading slash), breaking the service for users who had the leading slash in their configuration.

## Solution
- Store config entries in `hass.data` for service access
- Retrieve `topic_prefix` from config_entry instead of using hardcoded default
- Add debug logging to show the actual topic being published to
- Add cleanup of stored config entries on unload

## Testing
Tested successfully with topic_prefix configurations with leading slash: `/go-eCharger`

The service now correctly uses the user's configured topic_prefix regardless of the default value.
