### PR TITLE
Replace flake8/black/isort with ruff and fix lint issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,58 +1,32 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.4
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
     hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
+      - id: ruff-check
         args:
-          - --safe
-          - --quiet
-        files: ^((custom_components|homeassistant|script|tests)/.+)?[^/]+\.py$
+          - --fix
+        files: ^(custom_components|tests)/.+\.py$
+      - id: ruff-format
+        files: ^(custom_components|tests)/.+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.17.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:
           - --ignore-words-list=hass,alot,datas,dof,dur,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,hsa
-          - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-docstrings==1.5.0
-          - pydocstyle==5.0.2
-        files: ^(custom_components|homeassistant|script|tests)/.+\.py$
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
-    hooks:
-      - id: bandit
-        args:
-          - --quiet
-          - --format=custom
-          - --configfile=tests/bandit.yaml
-        files: ^(custom_components|homeassistant|script|tests)/.+\.py$
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.6.4
-    hooks:
-      - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
       - id: check-json
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
     hooks:
-      - id: mypy
-        args:
-          - --pretty
-          - --show-error-codes
-          - --show-error-context
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.6.2
+          - prettier-plugin-sort-json@4.2.0
+        files: ^custom_components/.+\.json$

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""go-eCharger MQTT integration."""

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) integration."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/goecharger_mqtt/binary_sensor.py
+++ b/custom_components/goecharger_mqtt/binary_sensor.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) binary sensor."""
+
 import logging
 
 from homeassistant import config_entries, core
@@ -86,13 +87,12 @@ class GoEChargerBinarySensor(GoEChargerEntity, BinarySensorEntity):
                 self._attr_is_on = self.entity_description.state(
                     message.payload, self.entity_description.attribute
                 )
+            elif message.payload == "true":
+                self._attr_is_on = True
+            elif message.payload == "false":
+                self._attr_is_on = False
             else:
-                if message.payload == "true":
-                    self._attr_is_on = True
-                elif message.payload == "false":
-                    self._attr_is_on = False
-                else:
-                    self._attr_is_on = None
+                self._attr_is_on = None
 
             self.async_write_ha_state()
 

--- a/custom_components/goecharger_mqtt/button.py
+++ b/custom_components/goecharger_mqtt/button.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) button."""
+
 import logging
 
 from homeassistant import config_entries, core

--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for go-eCharger (MQTT) integration."""
+
 from __future__ import annotations
 
 import logging
@@ -57,7 +58,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     hub = PlaceholderHub(data[CONF_TOPIC_PREFIX], serial_number)
 
     if not await hub.validate_device_topic():
-        raise CannotConnect
+        raise CannotConnectError
 
     return {"title": f"{DEFAULT_NAME} {serial_number}"}
 
@@ -128,9 +129,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             info = await validate_input(self.hass, user_input)
-        except CannotConnect:
+        except CannotConnectError:
             errors["base"] = "cannot_connect"
-        except InvalidAuth:
+        except InvalidAuthError:
             errors["base"] = "invalid_auth"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
@@ -146,9 +147,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-class CannotConnect(HomeAssistantError):
+class CannotConnectError(HomeAssistantError):
     """Error to indicate we cannot connect."""
 
 
-class InvalidAuth(HomeAssistantError):
+class InvalidAuthError(HomeAssistantError):
     """Error to indicate there is invalid auth."""

--- a/custom_components/goecharger_mqtt/definitions/binary_sensor.py
+++ b/custom_components/goecharger_mqtt/definitions/binary_sensor.py
@@ -1,4 +1,5 @@
 """Definitions for go-eCharger binary sensors exposed via MQTT."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/goecharger_mqtt/definitions/button.py
+++ b/custom_components/goecharger_mqtt/definitions/button.py
@@ -1,4 +1,5 @@
 """Definitions for go-eCharger buttons exposed via MQTT."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/goecharger_mqtt/definitions/number.py
+++ b/custom_components/goecharger_mqtt/definitions/number.py
@@ -1,4 +1,5 @@
 """Definitions for go-eCharger numbers exposed via MQTT."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/goecharger_mqtt/definitions/select.py
+++ b/custom_components/goecharger_mqtt/definitions/select.py
@@ -1,4 +1,5 @@
 """Definitions for go-eCharger select entities exposed via MQTT."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/goecharger_mqtt/definitions/sensor.py
+++ b/custom_components/goecharger_mqtt/definitions/sensor.py
@@ -108,7 +108,7 @@ def transform_code(value, mapping_table) -> str:
     try:
         return getattr(GoEChargerStatusCodes, mapping_table)[int(value)]
     except KeyError:
-        return "Definition missing for code %s" % value
+        return f"Definition missing for code {value}"
 
 
 SENSORS: tuple[GoEChargerSensorEntityDescription, ...] = (

--- a/custom_components/goecharger_mqtt/definitions/switch.py
+++ b/custom_components/goecharger_mqtt/definitions/switch.py
@@ -1,4 +1,5 @@
 """Definitions for go-eCharger switches exposed via MQTT."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/custom_components/goecharger_mqtt/number.py
+++ b/custom_components/goecharger_mqtt/number.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) switch."""
+
 import logging
 
 from homeassistant import config_entries, core
@@ -61,11 +62,10 @@ class GoEChargerNumber(GoEChargerEntity, NumberEntity):
                 self._attr_native_value = self.entity_description.state(
                     message.payload, self.entity_description.attribute
                 )
+            elif message.payload == "null":
+                self._attr_native_value = None
             else:
-                if message.payload == "null":
-                    self._attr_native_value = None
-                else:
-                    self._attr_native_value = message.payload
+                self._attr_native_value = message.payload
 
             self.async_write_ha_state()
 

--- a/custom_components/goecharger_mqtt/select.py
+++ b/custom_components/goecharger_mqtt/select.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) switch."""
+
 import logging
 
 from homeassistant import config_entries, core
@@ -79,7 +80,7 @@ class GoEChargerSelect(GoEChargerEntity, SelectEntity):
                 # if payload is None or payload in ["null", "none"]:
                 #     return
 
-                if payload not in self.entity_description.legacy_options.keys():
+                if payload not in self.entity_description.legacy_options:
                     _LOGGER.error(
                         "Invalid option for %s: '%s' (valid options: %s)",
                         self.entity_id,

--- a/custom_components/goecharger_mqtt/sensor.py
+++ b/custom_components/goecharger_mqtt/sensor.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) sensor."""
+
 import logging
 
 from homeassistant import config_entries, core
@@ -88,11 +89,10 @@ class GoEChargerSensor(GoEChargerEntity, SensorEntity):
                 self._attr_native_value = self.entity_description.state(
                     message.payload, self.entity_description.attribute
                 )
+            elif message.payload == "null":
+                self._attr_native_value = None
             else:
-                if message.payload == "null":
-                    self._attr_native_value = None
-                else:
-                    self._attr_native_value = message.payload
+                self._attr_native_value = message.payload
 
             self.async_write_ha_state()
 

--- a/custom_components/goecharger_mqtt/switch.py
+++ b/custom_components/goecharger_mqtt/switch.py
@@ -1,4 +1,5 @@
 """The go-eCharger (MQTT) switch."""
+
 import logging
 
 from homeassistant import config_entries, core
@@ -84,13 +85,12 @@ class GoEChargerSwitch(GoEChargerEntity, SwitchEntity):
                 self._attr_is_on = self.entity_description.state(
                     message.payload, self.entity_description.attribute
                 )
+            elif message.payload == self.entity_description.payload_on:
+                self._attr_is_on = True
+            elif message.payload == self.entity_description.payload_off:
+                self._attr_is_on = False
             else:
-                if message.payload == self.entity_description.payload_on:
-                    self._attr_is_on = True
-                elif message.payload == self.entity_description.payload_off:
-                    self._attr_is_on = False
-                else:
-                    self._attr_is_on = None
+                self._attr_is_on = None
 
             self.async_write_ha_state()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.ruff]
+required-version = ">=0.15.17"
+
+[tool.ruff.lint]
+select = [
+  "B",      # flake8-bugbear
+  "D",      # docstrings
+  "E",      # pycodestyle
+  "F",      # pyflakes
+  "I",      # isort
+  "N",      # pep8-naming
+  "PL",     # pylint
+  "RUF",    # ruff-specific
+  "SIM",    # flake8-simplify
+  "UP",     # pyupgrade
+]
+ignore = [
+  "D202",   # No blank lines allowed after function docstring
+  "D203",   # 1 blank line required before class docstring
+  "D213",   # Multi-line docstring summary should start at the second line
+  "D406",   # Section name should end with a newline
+  "D407",   # Section name underlining
+  "E501",   # line too long
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments
+  "PLR0915", # Too many statements
+  "PLR2004", # Magic value in comparison
+  "N815",    # mixedCase variable in class scope
+  "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["custom_components.goecharger_mqtt"]


### PR DESCRIPTION
## Summary

- Replaces flake8, black, isort, pyupgrade, bandit and mypy pre-commit hooks with a single **ruff** setup (aligned to HA core's `.pre-commit-config.yaml`)
- Adds **prettier** hook for JSON formatting
- Adds `pyproject.toml` with ruff config
- Fixes all lint issues found by ruff in existing code

## Lint fixes

- `PLR5501` — collapse `else: if/elif` into flat `elif` in `binary_sensor`, `number`, `sensor`, `switch`
- `N818` — rename `CannotConnect` → `CannotConnectError`, `InvalidAuth` → `InvalidAuthError`
- `SIM118` — remove `.keys()` from dict membership test in `select`
- `UP031` — replace `%` string formatting with f-string in `definitions/sensor`
- `D104` — add missing package docstrings

## Notes

`N815` and `RUF012` are suppressed in `pyproject.toml` because they affect `GoEChargerStatusCodes` which is removed in the follow-up translation layer PR.