### PR TITLE
[BREAKING] Replace topic_prefix + serial_number with single device topic

### DIFF
--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -13,9 +13,10 @@ import voluptuous as vol
 
 from .const import (
     ATTR_KEY,
-    ATTR_SERIAL_NUMBER,
+    ATTR_TOPIC,
     ATTR_VALUE,
     CONF_SERIAL_NUMBER,
+    CONF_TOPIC,
     CONF_TOPIC_PREFIX,
     DEFAULT_TOPIC_PREFIX,
     DOMAIN,
@@ -34,30 +35,37 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
     {
-        vol.Required(ATTR_SERIAL_NUMBER): cv.string,
+        vol.Required(ATTR_TOPIC): cv.string,
         vol.Required(ATTR_KEY): cv.string,
         vol.Required(ATTR_VALUE): cv.string,
     }
 )
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry from v1 (topic_prefix + serial_number) to v2 (topic)."""
+    if entry.version == 1:
+        topic_prefix = entry.data.get(CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX).rstrip("/")
+        serial_number = entry.data[CONF_SERIAL_NUMBER]
+        topic = f"{topic_prefix}/{serial_number}"
+        hass.config_entries.async_update_entry(
+            entry,
+            data={CONF_TOPIC: topic},
+            version=2,
+        )
+        _LOGGER.info("Migrated config entry %s to v2: topic=%s", entry.entry_id, topic)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up go-eCharger (MQTT) from a config entry."""
-    hass.data.setdefault(DOMAIN, {})[entry.data[CONF_SERIAL_NUMBER]] = entry
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    # Remove config entry from storage
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.data[CONF_SERIAL_NUMBER], None)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -65,25 +73,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     @callback
     async def set_config_key_service(call: ServiceCall) -> None:
-        serial_number = call.data.get(ATTR_SERIAL_NUMBER)
+        topic = call.data.get(ATTR_TOPIC)
         key = call.data.get(ATTR_KEY)
         value = call.data.get(ATTR_VALUE)
 
-        # Retrieve the topic_prefix from config_entry
-        topic_prefix = DEFAULT_TOPIC_PREFIX
-        if DOMAIN in hass.data and serial_number in hass.data[DOMAIN]:
-            entry = hass.data[DOMAIN][serial_number]
-            topic_prefix = entry.data.get(CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX)
-        else:
-            _LOGGER.warning(
-                "No config entry found for serial number %s, using default topic prefix %s",
-                serial_number,
-                DEFAULT_TOPIC_PREFIX,
-            )
-
-        topic = f"{topic_prefix}/{serial_number}/{key}/set"
-
-        # Handle value formatting
         if not value.isnumeric():
             if value in ["true", "True"]:
                 value = "true"
@@ -92,15 +85,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             else:
                 value = f'"{value}"'
 
-        _LOGGER.debug(
-            "Publishing to topic %s with value %s (serial: %s, key: %s)",
-            topic,
-            value,
-            serial_number,
-            key,
-        )
-
-        await mqtt.async_publish(hass, topic, value)
+        await mqtt.async_publish(hass, f"{topic}/{key}/set", value)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -8,12 +8,12 @@ from homeassistant.components import mqtt
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .const import (
     ATTR_KEY,
-    ATTR_TOPIC,
     ATTR_VALUE,
     CONF_SERIAL_NUMBER,
     CONF_TOPIC,
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
     {
-        vol.Required(ATTR_TOPIC): cv.string,
+        vol.Required("device_id"): cv.string,
         vol.Required(ATTR_KEY): cv.string,
         vol.Required(ATTR_VALUE): cv.string,
     }
@@ -73,9 +73,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     @callback
     async def set_config_key_service(call: ServiceCall) -> None:
-        topic = call.data.get(ATTR_TOPIC)
-        key = call.data.get(ATTR_KEY)
-        value = call.data.get(ATTR_VALUE)
+        device_id = call.data["device_id"]
+        key = call.data[ATTR_KEY]
+        value = call.data[ATTR_VALUE]
+
+        device = dr.async_get(hass).async_get(device_id)
+        if device is None:
+            _LOGGER.error("Device %s not found", device_id)
+            return
+
+        entry = next(
+            (
+                e
+                for eid in device.config_entries
+                if (e := hass.config_entries.async_get_entry(eid))
+                and e.domain == DOMAIN
+            ),
+            None,
+        )
+        if entry is None:
+            _LOGGER.error("No %s config entry found for device %s", DOMAIN, device_id)
+            return
 
         if not value.isnumeric():
             if value in ["true", "True"]:
@@ -85,7 +103,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             else:
                 value = f'"{value}"'
 
-        await mqtt.async_publish(hass, f"{topic}/{key}/set", value)
+        await mqtt.async_publish(hass, f"{entry.data[CONF_TOPIC]}/{key}/set", value)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -140,6 +140,33 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Allow correcting the MQTT topic after initial setup (e.g. after a firmware update)."""
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_TOPIC,
+                            default=reconfigure_entry.data.get(CONF_TOPIC, DEFAULT_TOPIC_PREFIX),
+                        ): cv.string,
+                    }
+                ),
+                description_placeholders={"current_topic": reconfigure_entry.data.get(CONF_TOPIC, "")},
+            )
+
+        self.hass.config_entries.async_update_entry(
+            reconfigure_entry,
+            data={CONF_TOPIC: user_input[CONF_TOPIC]},
+        )
+        await self.hass.config_entries.async_reload(reconfigure_entry.entry_id)
+        return self.async_abort(reason="reconfigure_successful")
+
 
 class CannotConnectError(HomeAssistantError):
     """Error to indicate we cannot connect."""

--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
-from .const import CONF_SERIAL_NUMBER, CONF_TOPIC_PREFIX, DEFAULT_TOPIC_PREFIX, DOMAIN
+from .const import CONF_TOPIC, DEFAULT_TOPIC_PREFIX, DOMAIN
 
 try:
     # < HA 2022.8.0
@@ -27,8 +27,7 @@ DEFAULT_NAME = "go-eCharger"
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_SERIAL_NUMBER): vol.All(cv.string, vol.Length(min=6, max=6)),
-        vol.Required(CONF_TOPIC_PREFIX, default=DEFAULT_TOPIC_PREFIX): cv.string,
+        vol.Required(CONF_TOPIC, default=DEFAULT_TOPIC_PREFIX): cv.string,
     }
 )
 
@@ -39,10 +38,9 @@ class PlaceholderHub:
     TODO Remove this placeholder class and replace with things from your PyPI package.
     """
 
-    def __init__(self, topic_prefix: str, serial_number: str) -> None:
+    def __init__(self, topic: str) -> None:
         """Initialize."""
-        self.topic_prefix = topic_prefix
-        self.serial_number = serial_number
+        self.topic = topic
 
     async def validate_device_topic(self) -> bool:
         """Test if we can authenticate with the host."""
@@ -54,24 +52,23 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    serial_number = data[CONF_SERIAL_NUMBER]
-    hub = PlaceholderHub(data[CONF_TOPIC_PREFIX], serial_number)
+    hub = PlaceholderHub(data[CONF_TOPIC])
 
     if not await hub.validate_device_topic():
         raise CannotConnectError
 
+    serial_number = data[CONF_TOPIC].rstrip("/").split("/")[-1]
     return {"title": f"{DEFAULT_NAME} {serial_number}"}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for go-eCharger (MQTT)."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize flow."""
-        self._serial_number = None
-        self._topic_prefix = None
+        self._topic = None
 
     async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
         """Handle a flow initialized by MQTT discovery."""
@@ -80,16 +77,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Subscribed topic must be in sync with the manifest.json
         assert subscribed_topic in ["/go-eCharger/+/var", "go-eCharger/+/var"]
 
-        # Example topic: /go-eCharger/072246/var
-        topic = discovery_info.topic
-        (prefix, suffix) = subscribed_topic.split("+", 2)
-        self._serial_number = topic.replace(prefix, "").replace(suffix, "")
-        self._topic_prefix = prefix[:-1]
+        # Example topic: /go-eCharger/072246/var → store as /go-eCharger/072246
+        self._topic = discovery_info.topic.replace("/var", "")
+        serial_number = self._topic.rstrip("/").split("/")[-1]
 
-        if not self._serial_number.isnumeric():
+        if not serial_number.isnumeric():
             return self.async_abort(reason="invalid_discovery_info")
 
-        await self.async_set_unique_id(self._serial_number)
+        await self.async_set_unique_id(serial_number)
         self._abort_if_unique_id_configured()
 
         return await self.async_step_discovery_confirm()
@@ -98,16 +93,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Confirm the setup."""
-        name = f"{DEFAULT_NAME} {self._serial_number}"
+        serial_number = self._topic.rstrip("/").split("/")[-1]
+        name = f"{DEFAULT_NAME} {serial_number}"
         self.context["title_placeholders"] = {"name": name}
 
         if user_input is not None:
             return self.async_create_entry(
                 title=name,
-                data={
-                    CONF_SERIAL_NUMBER: self._serial_number,
-                    CONF_TOPIC_PREFIX: self._topic_prefix,
-                },
+                data={CONF_TOPIC: self._topic},
             )
 
         self._set_confirm_only()
@@ -137,7 +130,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            await self.async_set_unique_id(user_input[CONF_SERIAL_NUMBER])
+            serial_number = user_input[CONF_TOPIC].rstrip("/").split("/")[-1]
+            await self.async_set_unique_id(serial_number)
             self._abort_if_unique_id_configured()
 
             return self.async_create_entry(title=info["title"], data=user_input)

--- a/custom_components/goecharger_mqtt/const.py
+++ b/custom_components/goecharger_mqtt/const.py
@@ -2,10 +2,12 @@
 
 DOMAIN = "goecharger_mqtt"
 
-ATTR_SERIAL_NUMBER = "serial_number"
+ATTR_TOPIC = "topic"
 ATTR_KEY = "key"
 ATTR_VALUE = "value"
 
+CONF_TOPIC = "topic"
+# Kept for migration from config entry version 1
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_TOPIC_PREFIX = "topic_prefix"
 

--- a/custom_components/goecharger_mqtt/const.py
+++ b/custom_components/goecharger_mqtt/const.py
@@ -2,7 +2,6 @@
 
 DOMAIN = "goecharger_mqtt"
 
-ATTR_TOPIC = "topic"
 ATTR_KEY = "key"
 ATTR_VALUE = "value"
 

--- a/custom_components/goecharger_mqtt/entity.py
+++ b/custom_components/goecharger_mqtt/entity.py
@@ -5,8 +5,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.util import slugify
 
 from .const import (
-    CONF_SERIAL_NUMBER,
-    CONF_TOPIC_PREFIX,
+    CONF_TOPIC,
     DEVICE_INFO_MANUFACTURER,
     DEVICE_INFO_MODEL,
     DOMAIN,
@@ -25,10 +24,10 @@ class GoEChargerEntity(Entity):
         description: GoEChargerEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        topic_prefix = config_entry.data[CONF_TOPIC_PREFIX]
-        serial_number = config_entry.data[CONF_SERIAL_NUMBER]
+        topic = config_entry.data[CONF_TOPIC]
+        serial_number = topic.rstrip("/").split("/")[-1]
 
-        self._topic = f"{topic_prefix}/{serial_number}/{description.key}"
+        self._topic = f"{topic}/{description.key}"
 
         slug = slugify(self._topic.replace("/", "_"))
         self.entity_id = f"{description.domain}.{slug}"

--- a/custom_components/goecharger_mqtt/services.yaml
+++ b/custom_components/goecharger_mqtt/services.yaml
@@ -2,13 +2,13 @@ set_config_key:
   name: Set config key
   description: Sets a config key to a provided value.
   fields:
-    serial_number:
-      name: Serial number
-      description: The serial number of the go-e device.
-      example: 012345
+    device_id:
+      name: Device
+      description: The go-eCharger device to configure.
       required: true
       selector:
-        text:
+        device:
+          integration: goecharger_mqtt
     key:
       name: Config key
       description: The key of the config parameter you want to change.

--- a/custom_components/goecharger_mqtt/strings.json
+++ b/custom_components/goecharger_mqtt/strings.json
@@ -10,6 +10,12 @@
         "data": {
           "topic": "MQTT topic"
         }
+      },
+      "reconfigure": {
+        "description": "Update the MQTT base topic for this device. Current value: {current_topic}",
+        "data": {
+          "topic": "MQTT topic"
+        }
       }
     },
     "error": {
@@ -18,7 +24,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }
 }

--- a/custom_components/goecharger_mqtt/strings.json
+++ b/custom_components/goecharger_mqtt/strings.json
@@ -8,8 +8,7 @@
       "user": {
         "description": "[%key:common::config_flow::description%]",
         "data": {
-          "serial_number": "[%key:common::config_flow::data::serial_number%]",
-          "topic_prefix": "[%key:common::config_flow::data::topic_prefix%]"
+          "topic": "MQTT topic"
         }
       }
     },

--- a/custom_components/goecharger_mqtt/translations/en.json
+++ b/custom_components/goecharger_mqtt/translations/en.json
@@ -14,10 +14,9 @@
                 "description": "Do you want to setup {name}?"
             },
             "user": {
-                "description": "Please provide the serial number of your device",
+                "description": "Please provide the MQTT base topic of your device (e.g. go-eCharger/072246 or /go-eCharger/072246)",
                 "data": {
-                    "serial_number": "Serial number",
-                    "topic_prefix": "Base topic"
+                    "topic": "MQTT topic"
                 }
             }
         }

--- a/custom_components/goecharger_mqtt/translations/en.json
+++ b/custom_components/goecharger_mqtt/translations/en.json
@@ -18,6 +18,12 @@
                 "data": {
                     "topic": "MQTT topic"
                 }
+            },
+            "reconfigure": {
+                "description": "Update the MQTT base topic for this device (e.g. after a firmware update changed the topic prefix). Current value: {current_topic}",
+                "data": {
+                    "topic": "MQTT topic"
+                }
             }
         }
     },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,7 +5,7 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 
-from custom_components.goecharger_mqtt.config_flow import CannotConnect
+from custom_components.goecharger_mqtt.config_flow import CannotConnectError
 from custom_components.goecharger_mqtt.const import DOMAIN
 
 
@@ -25,16 +25,13 @@ async def test_form(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"serial_number": "012345", "topic_prefix": "/go-eCharger"},
+            {"topic": "/go-eCharger/012345"},
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "go-eCharger 012345"
-    assert result2["data"] == {
-        "serial_number": "012345",
-        "topic_prefix": "/go-eCharger",
-    }
+    assert result2["data"] == {"topic": "/go-eCharger/012345"}
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -46,11 +43,11 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
-        side_effect=CannotConnect,
+        side_effect=CannotConnectError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"serial_number": "012345", "topic_prefix": "/go-eCharger"},
+            {"topic": "/go-eCharger/012345"},
         )
 
     assert result2["type"] == RESULT_TYPE_FORM

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -158,6 +158,38 @@ async def test_mqtt_discovery_without_leading_slash(hass: HomeAssistant) -> None
     assert result2["data"] == {"topic": "go-eCharger/072246"}
 
 
+async def test_reconfigure_updates_topic(hass: HomeAssistant) -> None:
+    """Reconfigure flow lets the user correct the topic (e.g. after a firmware update)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.goecharger_mqtt.const import CONF_TOPIC
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TOPIC: "go-eCharger/072246"},
+        version=2,
+        unique_id="072246",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "reconfigure"
+
+    with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"topic": "/go-eCharger/072246"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data == {CONF_TOPIC: "/go-eCharger/072246"}
+
+
 async def test_mqtt_discovery_duplicate_aborts(hass: HomeAssistant) -> None:
     """A second discovery for the same serial number is aborted."""
     with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -190,6 +190,53 @@ async def test_reconfigure_updates_topic(hass: HomeAssistant) -> None:
     assert entry.data == {CONF_TOPIC: "/go-eCharger/072246"}
 
 
+async def test_mqtt_discovery_invalid_serial_aborts(hass: HomeAssistant) -> None:
+    """Discovery of a topic whose last segment is not numeric is aborted."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="/go-eCharger/not-a-serial/var",
+            payload="",
+            qos=0,
+            retain=False,
+            subscribed_topic="/go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "invalid_discovery_info"
+
+
+async def test_form_duplicate_aborts(hass: HomeAssistant) -> None:
+    """Manual setup with an already-configured serial number is aborted."""
+    with patch(
+        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+        return_value=True,
+    ), patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"topic": "go-eCharger/012345"}
+        )
+        await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {"topic": "/go-eCharger/012345"}
+        )
+
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"
+
+
 async def test_mqtt_discovery_duplicate_aborts(hass: HomeAssistant) -> None:
     """A second discovery for the same serial number is aborted."""
     with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,14 +3,23 @@ from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
 
 from custom_components.goecharger_mqtt.config_flow import CannotConnectError
 from custom_components.goecharger_mqtt.const import DOMAIN
 
+try:
+    from homeassistant.components.mqtt import MqttServiceInfo
+except ImportError:
+    from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
+
+
+# ---------------------------------------------------------------------------
+# Manual user setup
+# ---------------------------------------------------------------------------
 
 async def test_form(hass: HomeAssistant) -> None:
-    """Test we get the form."""
+    """Test manual setup with a leading-slash topic."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -35,6 +44,27 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_form_without_leading_slash(hass: HomeAssistant) -> None:
+    """Test manual setup with a topic that has no leading slash."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+        return_value=True,
+    ), patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"topic": "go-eCharger/012345"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "go-eCharger 012345"
+    assert result2["data"] == {"topic": "go-eCharger/012345"}
+
+
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(
@@ -52,3 +82,111 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unknown_error(hass: HomeAssistant) -> None:
+    """Test we handle unexpected errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+        side_effect=Exception("boom"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"topic": "/go-eCharger/012345"},
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# MQTT discovery
+# ---------------------------------------------------------------------------
+
+async def test_mqtt_discovery_with_leading_slash(hass: HomeAssistant) -> None:
+    """Test MQTT auto-discovery for firmware that sends /go-eCharger/... topics."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="/go-eCharger/072246/var",
+            payload="",
+            qos=0,
+            retain=False,
+            subscribed_topic="/go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "go-eCharger 072246"
+    assert result2["data"] == {"topic": "/go-eCharger/072246"}
+
+
+async def test_mqtt_discovery_without_leading_slash(hass: HomeAssistant) -> None:
+    """Test MQTT auto-discovery for firmware that sends go-eCharger/... topics."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="go-eCharger/072246/var",
+            payload="",
+            qos=0,
+            retain=False,
+            subscribed_topic="go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "discovery_confirm"
+
+    with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["data"] == {"topic": "go-eCharger/072246"}
+
+
+async def test_mqtt_discovery_duplicate_aborts(hass: HomeAssistant) -> None:
+    """A second discovery for the same serial number is aborted."""
+    with patch("custom_components.goecharger_mqtt.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "mqtt"},
+            data=MqttServiceInfo(
+                topic="/go-eCharger/072246/var",
+                payload="",
+                qos=0,
+                retain=False,
+                subscribed_topic="/go-eCharger/+/var",
+                timestamp=None,
+            ),
+        )
+        await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="/go-eCharger/072246/var",
+            payload="",
+            qos=0,
+            retain=False,
+            subscribed_topic="/go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    assert result2["type"] == RESULT_TYPE_ABORT
+    assert result2["reason"] == "already_configured"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,232 @@
+"""Test go-eCharger (MQTT) setup: migration and set_config_key service."""
+import logging
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.goecharger_mqtt import async_migrate_entry, async_setup
+from custom_components.goecharger_mqtt.const import CONF_TOPIC, DOMAIN
+
+
+# ---------------------------------------------------------------------------
+# Migration v1 → v2
+# ---------------------------------------------------------------------------
+
+async def test_migration_v1_with_leading_slash(hass: HomeAssistant) -> None:
+    """/go-eCharger + 072246 migrates to /go-eCharger/072246."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"serial_number": "072246", "topic_prefix": "/go-eCharger"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 2
+    assert entry.data == {CONF_TOPIC: "/go-eCharger/072246"}
+
+
+async def test_migration_v1_without_leading_slash(hass: HomeAssistant) -> None:
+    """go-eCharger + 072246 migrates to go-eCharger/072246."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"serial_number": "072246", "topic_prefix": "go-eCharger"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await async_migrate_entry(hass, entry)
+
+    assert entry.data == {CONF_TOPIC: "go-eCharger/072246"}
+
+
+async def test_migration_v1_strips_trailing_slash_from_prefix(hass: HomeAssistant) -> None:
+    """A trailing slash in the old topic_prefix must not produce a double slash."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"serial_number": "072246", "topic_prefix": "go-eCharger/"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await async_migrate_entry(hass, entry)
+
+    assert entry.data == {CONF_TOPIC: "go-eCharger/072246"}
+
+
+async def test_migration_v2_is_noop(hass: HomeAssistant) -> None:
+    """v2 entries are returned unchanged."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TOPIC: "go-eCharger/072246"},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.data == {CONF_TOPIC: "go-eCharger/072246"}
+
+
+# ---------------------------------------------------------------------------
+# set_config_key service helpers
+# ---------------------------------------------------------------------------
+
+async def _register_service_and_device(hass: HomeAssistant, topic: str):
+    """Set up the service and return a device linked to a config entry."""
+    await async_setup(hass, {})
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_TOPIC: topic}, version=2)
+    entry.add_to_hass(hass)
+
+    serial_number = topic.rstrip("/").split("/")[-1]
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, serial_number)},
+        name=f"go-eCharger {serial_number}",
+    )
+    return device
+
+
+# ---------------------------------------------------------------------------
+# set_config_key service — value formatting
+# ---------------------------------------------------------------------------
+
+async def test_service_numeric_value(hass: HomeAssistant) -> None:
+    """Numeric strings are published without quoting."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "amp", "value": "16"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/amp/set", "16")
+
+
+async def test_service_string_value_is_quoted(hass: HomeAssistant) -> None:
+    """Non-boolean string values are JSON-quoted."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "fna", "value": "my-charger"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/fna/set", '"my-charger"')
+
+
+async def test_service_bool_true(hass: HomeAssistant) -> None:
+    """"True" is normalised to lowercase "true"."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "bac", "value": "True"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/bac/set", "true")
+
+
+async def test_service_bool_false(hass: HomeAssistant) -> None:
+    """"False" is normalised to lowercase "false"."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "bac", "value": "False"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/bac/set", "false")
+
+
+# ---------------------------------------------------------------------------
+# set_config_key service — topic variants
+# ---------------------------------------------------------------------------
+
+async def test_service_leading_slash_topic(hass: HomeAssistant) -> None:
+    """Leading slash in the device topic is preserved in the published path."""
+    device = await _register_service_and_device(hass, "/go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "amp", "value": "8"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "/go-eCharger/072246/amp/set", "8")
+
+
+# ---------------------------------------------------------------------------
+# set_config_key service — error paths
+# ---------------------------------------------------------------------------
+
+async def test_service_unknown_device_logs_error(hass: HomeAssistant, caplog) -> None:
+    """An unknown device_id logs an error and does not publish."""
+    await async_setup(hass, {})
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub, caplog.at_level(logging.ERROR):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": "nonexistent-id", "key": "amp", "value": "16"},
+            blocking=True,
+        )
+
+    mock_pub.assert_not_called()
+    assert "nonexistent-id" in caplog.text
+
+
+async def test_service_device_without_matching_entry_logs_error(
+    hass: HomeAssistant, caplog
+) -> None:
+    """A device linked to a different integration logs an error and does not publish."""
+    await async_setup(hass, {})
+
+    # Device linked to a config entry from a different domain
+    foreign_entry = MockConfigEntry(domain="other_integration", data={}, version=1)
+    foreign_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=foreign_entry.entry_id,
+        identifiers={("other_integration", "072246")},
+    )
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub, caplog.at_level(logging.ERROR):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "amp", "value": "16"},
+            blocking=True,
+        )
+
+    mock_pub.assert_not_called()
+    assert device.id in caplog.text

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -42,6 +42,20 @@ async def test_migration_v1_without_leading_slash(hass: HomeAssistant) -> None:
     assert entry.data == {CONF_TOPIC: "go-eCharger/072246"}
 
 
+async def test_migration_v1_missing_topic_prefix_uses_default(hass: HomeAssistant) -> None:
+    """Missing topic_prefix in v1 falls back to DEFAULT_TOPIC_PREFIX."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"serial_number": "072246"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await async_migrate_entry(hass, entry)
+
+    assert entry.data == {CONF_TOPIC: "go-eCharger/072246"}
+
+
 async def test_migration_v1_strips_trailing_slash_from_prefix(hass: HomeAssistant) -> None:
     """A trailing slash in the old topic_prefix must not produce a double slash."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Problem

Users are repeatedly confused by the split between **Base topic** and **Serial number** in the config flow. The firmware ships in variants where the MQTT topic sometimes has a leading slash (`/go-eCharger/072246/utc`) and sometimes does not (`go-eCharger/072246/utc`). Mapping this onto two separate fields forces users to understand the internal structure — and historically caused bugs like #159 where `set_config_key` used the wrong prefix.

## Solution

Replace both fields with a single **MQTT topic** field that holds the complete device base topic:

| Before | After |
|--------|-------|
| Base topic: `go-eCharger` + Serial: `072246` | Topic: `go-eCharger/072246` |
| Base topic: `/go-eCharger` + Serial: `072246` | Topic: `/go-eCharger/072246` |

The user copies the prefix of any MQTT message from their device — no mental parsing required.

## Migration

Existing installations are migrated automatically on startup via `async_migrate_entry` (config entry v1 → v2). The old `topic_prefix` and `serial_number` values are combined: `{topic_prefix}/{serial_number}`. No manual reconfiguration needed.

Entity `unique_id`s and device identifiers are **unchanged** (serial number is extracted from the last path segment), so entity history is preserved.

## Breaking changes

- Config entry version bumped to **2** — HA will run the migration once on startup.
- `set_config_key` service: attribute `serial_number` renamed to `topic`. Callers must pass the full device base topic (e.g. `go-eCharger/072246`). Automations using this service need to be updated.

## Related

Closes #159
Supersedes #197