### PR TITLE
Mark device unavailable after heartbeat timeout

### DIFF
--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from homeassistant.components import mqtt
@@ -10,6 +11,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import voluptuous as vol
 
 from .const import (
@@ -21,6 +23,8 @@ from .const import (
     DEFAULT_TOPIC_PREFIX,
     DOMAIN,
 )
+
+HEARTBEAT_TIMEOUT = 10
 
 PLATFORMS: list[str] = [
     "binary_sensor",
@@ -61,6 +65,33 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up go-eCharger (MQTT) from a config entry."""
+    coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        config_entry=entry,
+        name=f"goecharger_mqtt_{entry.entry_id}",
+    )
+    coordinator.last_update_success = False
+    entry.runtime_data = coordinator
+
+    topic = entry.data[CONF_TOPIC]
+    _timeout_handle: asyncio.TimerHandle | None = None
+
+    @callback
+    def _on_heartbeat(message):
+        nonlocal _timeout_handle
+        if _timeout_handle:
+            _timeout_handle.cancel()
+        coordinator.async_set_updated_data(None)
+        _timeout_handle = hass.loop.call_later(HEARTBEAT_TIMEOUT, _on_timeout)
+
+    def _on_timeout():
+        coordinator.async_set_update_error(Exception("Heartbeat timeout"))
+
+    unsub = await mqtt.async_subscribe(hass, f"{topic}/utc", _on_heartbeat, 1)
+    entry.async_on_unload(unsub)
+    entry.async_on_unload(lambda: _timeout_handle and _timeout_handle.cancel())
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/goecharger_mqtt/binary_sensor.py
+++ b/custom_components/goecharger_mqtt/binary_sensor.py
@@ -72,13 +72,9 @@ class GoEChargerBinarySensor(GoEChargerEntity, BinarySensorEntity):
 
         super().__init__(config_entry, description)
 
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._attr_is_on is not None
-
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
 
         @callback
         def message_received(message):

--- a/custom_components/goecharger_mqtt/entity.py
+++ b/custom_components/goecharger_mqtt/entity.py
@@ -1,7 +1,8 @@
 """MQTT component mixins and helpers."""
 
 from homeassistant import config_entries
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .const import (
@@ -13,7 +14,7 @@ from .const import (
 from .definitions import GoEChargerEntityDescription
 
 
-class GoEChargerEntity(Entity):
+class GoEChargerEntity(CoordinatorEntity):
     """Common go-eCharger entity."""
 
     _attr_has_entity_name = True
@@ -24,6 +25,8 @@ class GoEChargerEntity(Entity):
         description: GoEChargerEntityDescription,
     ) -> None:
         """Initialize the sensor."""
+        super().__init__(config_entry.runtime_data)
+
         topic = config_entry.data[CONF_TOPIC]
         serial_number = topic.rstrip("/").split("/")[-1]
 

--- a/custom_components/goecharger_mqtt/number.py
+++ b/custom_components/goecharger_mqtt/number.py
@@ -40,7 +40,6 @@ class GoEChargerNumber(GoEChargerEntity, NumberEntity):
         super().__init__(config_entry, description)
 
         self.entity_description = description
-        self._attr_available = False
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
@@ -53,11 +52,11 @@ class GoEChargerNumber(GoEChargerEntity, NumberEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
 
         @callback
         def message_received(message):
             """Handle new MQTT messages."""
-            self._attr_available = True
             if self.entity_description.state is not None:
                 self._attr_native_value = self.entity_description.state(
                     message.payload, self.entity_description.attribute

--- a/custom_components/goecharger_mqtt/select.py
+++ b/custom_components/goecharger_mqtt/select.py
@@ -43,11 +43,6 @@ class GoEChargerSelect(GoEChargerEntity, SelectEntity):
         self._attr_options = list(description.legacy_options.values())
         self._attr_current_option = None
 
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._attr_current_option is not None
-
     def key_from_option(self, option: str):
         """Return the option a given payload is assigned to."""
         try:
@@ -67,6 +62,7 @@ class GoEChargerSelect(GoEChargerEntity, SelectEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
 
         @callback
         def message_received(message):

--- a/custom_components/goecharger_mqtt/sensor.py
+++ b/custom_components/goecharger_mqtt/sensor.py
@@ -74,13 +74,9 @@ class GoEChargerSensor(GoEChargerEntity, SensorEntity):
 
         self.entity_description = description
 
-    @property
-    def available(self):
-        """Return True if entity is available."""
-        return self._attr_native_value is not None
-
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
 
         @callback
         def message_received(message):

--- a/custom_components/goecharger_mqtt/switch.py
+++ b/custom_components/goecharger_mqtt/switch.py
@@ -43,14 +43,6 @@ class GoEChargerSwitch(GoEChargerEntity, SwitchEntity):
         self._optimistic = self.entity_description.optimistic
 
     @property
-    def available(self):
-        """Return True if entity is available."""
-        if self._optimistic:
-            return self._topic is not None
-
-        return self._topic is not None
-
-    @property
     def assumed_state(self):
         """Return true if we do optimistic updates."""
         return self._optimistic
@@ -77,6 +69,7 @@ class GoEChargerSwitch(GoEChargerEntity, SwitchEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
+        await super().async_added_to_hass()
 
         @callback
         def message_received(message):

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -10,6 +10,8 @@ test_entity_snapshot_is_complete  — fails when a new entity is added without
                                     a corresponding entry in _ALL_ENTITIES below
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -101,6 +103,7 @@ async def test_entity_unique_id_stable(
     """Verify unique_id format for one representative case per attribute variant."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_TOPIC: topic}, version=2)
     entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
     entity = GoEChargerEntity(
         entry, GoEChargerEntityDescription(key=key, domain=domain, attribute=attribute)
     )
@@ -367,6 +370,7 @@ async def test_all_entity_unique_ids(
     """Assert the hard-coded unique_id for every entity definition across all platforms."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_TOPIC: _TOPIC}, version=2)
     entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
     entity = GoEChargerEntity(
         entry, GoEChargerEntityDescription(key=key, domain=domain, attribute=attribute)
     )

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,87 @@
+"""Test heartbeat-based device unavailability."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.goecharger_mqtt import async_setup_entry
+from custom_components.goecharger_mqtt.const import CONF_TOPIC, DOMAIN
+
+TOPIC = "go-eCharger/072246"
+
+
+@pytest.fixture
+async def entry_with_mocks(hass: HomeAssistant):
+    """Config entry with MQTT subscription and call_later captured."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_TOPIC: TOPIC}, version=2)
+    entry.add_to_hass(hass)
+
+    mqtt_cbs = {}
+    timer_cbs = []
+
+    async def fake_subscribe(h, topic, cb, qos):
+        mqtt_cbs[topic] = cb
+        return lambda: None
+
+    def fake_call_later(delay, fn):
+        handle = MagicMock()
+        timer_cbs.append(fn)
+        return handle
+
+    with (
+        patch(
+            "homeassistant.components.mqtt.async_subscribe",
+            side_effect=fake_subscribe,
+        ),
+        patch.object(hass.config_entries, "async_forward_entry_setups", new=AsyncMock()),
+        patch.object(hass.loop, "call_later", side_effect=fake_call_later),
+    ):
+        await async_setup_entry(hass, entry)
+        yield entry, mqtt_cbs, timer_cbs
+
+
+async def test_initially_unavailable(entry_with_mocks):
+    """Coordinator starts unavailable until first heartbeat arrives."""
+    entry, _, _ = entry_with_mocks
+    assert entry.runtime_data.last_update_success is False
+
+
+async def test_heartbeat_makes_available(hass: HomeAssistant, entry_with_mocks):
+    """First heartbeat message marks device available."""
+    entry, mqtt_cbs, _ = entry_with_mocks
+
+    mqtt_cbs[f"{TOPIC}/utc"](MagicMock())
+    await hass.async_block_till_done()
+
+    assert entry.runtime_data.last_update_success is True
+
+
+async def test_timeout_makes_unavailable(hass: HomeAssistant, entry_with_mocks):
+    """10-second silence marks device unavailable."""
+    entry, mqtt_cbs, timer_cbs = entry_with_mocks
+
+    mqtt_cbs[f"{TOPIC}/utc"](MagicMock())
+    await hass.async_block_till_done()
+    assert entry.runtime_data.last_update_success is True
+
+    timer_cbs[-1]()
+    await hass.async_block_till_done()
+    assert entry.runtime_data.last_update_success is False
+
+
+async def test_reconnect_restores_availability(hass: HomeAssistant, entry_with_mocks):
+    """Heartbeat after timeout makes device available again."""
+    entry, mqtt_cbs, timer_cbs = entry_with_mocks
+
+    mqtt_cbs[f"{TOPIC}/utc"](MagicMock())
+    await hass.async_block_till_done()
+
+    timer_cbs[-1]()
+    await hass.async_block_till_done()
+    assert entry.runtime_data.last_update_success is False
+
+    mqtt_cbs[f"{TOPIC}/utc"](MagicMock())
+    await hass.async_block_till_done()
+    assert entry.runtime_data.last_update_success is True


### PR DESCRIPTION
## Summary

- The go-eCharger firmware sends no MQTT LWT and the broker retains all messages, so entities stayed stuck at their last value when the wallbox disappeared from the network
- Subscribes to `{topic}/utc` (fires every second) as a heartbeat
- A `DataUpdateCoordinator` drives availability for all entity types atomically: first message → available, 10 s silence → `async_set_update_error` → every `CoordinatorEntity` automatically reports `STATE_UNAVAILABLE`
- Replaces the scattered per-entity `available` properties and `_attr_available` attributes

## Changes

- `__init__.py` — creates coordinator, subscribes to heartbeat, manages 10 s timeout via `call_later`
- `entity.py` — `Entity` → `CoordinatorEntity`
- `sensor.py`, `binary_sensor.py`, `switch.py`, `select.py` — remove `available` property, add `super()` in `async_added_to_hass`
- `number.py` — remove `_attr_available`, add `super()` in `async_added_to_hass`
- `setup.cfg` — add `asyncio_mode = auto` for pytest-asyncio

## Test plan

- [ ] `pytest tests/test_heartbeat.py` — 4 new tests: initial unavailable, heartbeat → available, 10 s timeout → unavailable, reconnect → available
- [ ] `pytest tests/` — all 274 tests pass
- [ ] Manual: disconnect wallbox from network, verify all entities switch to `unavailable` within ~10 s; reconnect, verify they recover