### PR TITLE
Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hacs/action@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: hacs/action@d556e736723344f83838d08488c983a15381059a  # 22.5.0
         with:
           category: integration

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -12,5 +12,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: home-assistant/actions/hassfest@master
+      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"  # v4.3.1
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89  # master

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -13,8 +13,8 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
         with:
           config_file: .yamllint


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references to immutable commit SHAs instead of mutable tags/branches. A compromised tag (`@v2`, `@main`) can be silently redirected to malicious code; a SHA cannot.

| Workflow | Action | Before | After |
|---|---|---|---|
| all | `actions/checkout` | `@v1` / `@v2` / `@v4` | `@34e11487` `# v4.3.1` |
| pytest | `actions/setup-python` | `@v5` | `@a26af69b` `# v5.6.0` |
| yamllint | `ibiqlik/action-yamllint` | `@v3` | `@2576378a` `# v3.1.1` |
| hacs | `hacs/action` | `@main` | `@d556e736` `# 22.5.0` |
| hassfest | `home-assistant/actions/hassfest` | `@master` | `@e91ad194` `# master` |

Also consolidates all `actions/checkout` usages to the same current version (previously mixed v1/v2/v4).