### PR TITLE
Add update_grid_power service for PV surplus / zero feed-in control

### DIFF
--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -53,7 +53,7 @@ SERVICE_SCHEMA_UPDATE_GRID_POWER = vol.Schema(
         vol.Required("device_id"): cv.string,
         vol.Required("power_grid"): vol.Coerce(float),
         vol.Optional("power_pv"): vol.Coerce(float),
-        vol.Optional("power_akku"): vol.Coerce(float),
+        vol.Optional("power_battery"): vol.Coerce(float),
     }
 )
 
@@ -175,8 +175,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         payload: dict[str, float] = {"pGrid": call.data["power_grid"]}
         if "power_pv" in call.data:
             payload["pPv"] = call.data["power_pv"]
-        if "power_akku" in call.data:
-            payload["pAkku"] = call.data["power_akku"]
+        if "power_battery" in call.data:
+            payload["pAkku"] = call.data["power_battery"]
 
         await mqtt.async_publish(
             hass,

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -51,9 +51,9 @@ SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
 SERVICE_SCHEMA_UPDATE_GRID_POWER = vol.Schema(
     {
         vol.Required("device_id"): cv.string,
-        vol.Required("p_grid"): vol.Coerce(float),
-        vol.Optional("p_pv"): vol.Coerce(float),
-        vol.Optional("p_akku"): vol.Coerce(float),
+        vol.Required("power_grid"): vol.Coerce(float),
+        vol.Optional("power_pv"): vol.Coerce(float),
+        vol.Optional("power_akku"): vol.Coerce(float),
     }
 )
 
@@ -172,11 +172,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if entry is None:
             return
 
-        payload: dict[str, float] = {"pGrid": call.data["p_grid"]}
-        if "p_pv" in call.data:
-            payload["pPv"] = call.data["p_pv"]
-        if "p_akku" in call.data:
-            payload["pAkku"] = call.data["p_akku"]
+        payload: dict[str, float] = {"pGrid": call.data["power_grid"]}
+        if "power_pv" in call.data:
+            payload["pPv"] = call.data["power_pv"]
+        if "power_akku" in call.data:
+            payload["pAkku"] = call.data["power_akku"]
 
         await mqtt.async_publish(
             hass,

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -172,11 +172,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if entry is None:
             return
 
-        payload: dict[str, float] = {"pGrid": call.data["power_grid"]}
+        payload: dict[str, float] = {"pGrid": round(call.data["power_grid"], 1)}
         if "power_pv" in call.data:
-            payload["pPv"] = call.data["power_pv"]
+            payload["pPv"] = round(call.data["power_pv"], 1)
         if "power_battery" in call.data:
-            payload["pAkku"] = call.data["power_battery"]
+            payload["pAkku"] = round(call.data["power_battery"], 1)
 
         await mqtt.async_publish(
             hass,

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 from homeassistant.components import mqtt
@@ -44,6 +45,15 @@ SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
         vol.Required("device_id"): cv.string,
         vol.Required(ATTR_KEY): cv.string,
         vol.Required(ATTR_VALUE): cv.string,
+    }
+)
+
+SERVICE_SCHEMA_UPDATE_GRID_POWER = vol.Schema(
+    {
+        vol.Required("device_id"): cv.string,
+        vol.Required("p_grid"): vol.Coerce(float),
+        vol.Optional("p_pv"): vol.Coerce(float),
+        vol.Optional("p_akku"): vol.Coerce(float),
     }
 )
 
@@ -116,32 +126,36 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+def _entry_for_device(hass: HomeAssistant, device_id: str) -> ConfigEntry | None:
+    device = dr.async_get(hass).async_get(device_id)
+    if device is None:
+        _LOGGER.error("Device %s not found", device_id)
+        return None
+    entry = next(
+        (
+            e
+            for eid in device.config_entries
+            if (e := hass.config_entries.async_get_entry(eid))
+            and e.domain == DOMAIN
+        ),
+        None,
+    )
+    if entry is None:
+        _LOGGER.error("No %s config entry found for device %s", DOMAIN, device_id)
+    return entry
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up integration."""
 
     @callback
     async def set_config_key_service(call: ServiceCall) -> None:
-        device_id = call.data["device_id"]
+        entry = _entry_for_device(hass, call.data["device_id"])
+        if entry is None:
+            return
+
         key = call.data[ATTR_KEY]
         value = call.data[ATTR_VALUE]
-
-        device = dr.async_get(hass).async_get(device_id)
-        if device is None:
-            _LOGGER.error("Device %s not found", device_id)
-            return
-
-        entry = next(
-            (
-                e
-                for eid in device.config_entries
-                if (e := hass.config_entries.async_get_entry(eid))
-                and e.domain == DOMAIN
-            ),
-            None,
-        )
-        if entry is None:
-            _LOGGER.error("No %s config entry found for device %s", DOMAIN, device_id)
-            return
 
         if not value.isnumeric():
             if value in ["true", "True"]:
@@ -153,11 +167,34 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         await mqtt.async_publish(hass, f"{entry.data[CONF_TOPIC]}/{key}/set", value)
 
+    async def update_grid_power_service(call: ServiceCall) -> None:
+        entry = _entry_for_device(hass, call.data["device_id"])
+        if entry is None:
+            return
+
+        payload: dict[str, float] = {"pGrid": call.data["p_grid"]}
+        if "p_pv" in call.data:
+            payload["pPv"] = call.data["p_pv"]
+        if "p_akku" in call.data:
+            payload["pAkku"] = call.data["p_akku"]
+
+        await mqtt.async_publish(
+            hass,
+            f"{entry.data[CONF_TOPIC]}/ids/set",
+            json.dumps(payload),
+        )
+
     hass.services.async_register(
         DOMAIN,
         "set_config_key",
         set_config_key_service,
         schema=SERVICE_SCHEMA_SET_CONFIG_KEY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "update_grid_power",
+        update_grid_power_service,
+        schema=SERVICE_SCHEMA_UPDATE_GRID_POWER,
     )
 
     return True

--- a/custom_components/goecharger_mqtt/services.yaml
+++ b/custom_components/goecharger_mqtt/services.yaml
@@ -1,3 +1,50 @@
+update_grid_power:
+  name: Update grid power
+  description: >
+    Publishes real-time grid power data to the wallbox (ids API key).
+    Must be called repeatedly every 5 seconds or less while PV surplus
+    or zero feed-in control is active; the wallbox does not stop
+    automatically when updates cease.
+  fields:
+    device_id:
+      name: Device
+      description: The go-eCharger device to update.
+      required: true
+      selector:
+        device:
+          integration: goecharger_mqtt
+    p_grid:
+      name: Grid power (W)
+      description: >
+        Current grid power in watts. Positive = importing from grid,
+        negative = exporting to grid.
+      required: true
+      selector:
+        number:
+          min: -100000
+          max: 100000
+          unit_of_measurement: W
+    p_pv:
+      name: PV power (W)
+      description: Current PV generation in watts (optional).
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100000
+          unit_of_measurement: W
+    p_akku:
+      name: Battery power (W)
+      description: >
+        Current battery power in watts. Positive = charging,
+        negative = discharging (optional).
+      required: false
+      selector:
+        number:
+          min: -100000
+          max: 100000
+          unit_of_measurement: W
+
 set_config_key:
   name: Set config key
   description: Sets a config key to a provided value.

--- a/custom_components/goecharger_mqtt/services.yaml
+++ b/custom_components/goecharger_mqtt/services.yaml
@@ -13,18 +13,16 @@ update_grid_power:
       selector:
         device:
           integration: goecharger_mqtt
-    p_grid:
+    power_grid:
       name: Grid power (W)
-      description: >
-        Current grid power in watts. Positive = importing from grid,
-        negative = exporting to grid.
+      description: Current grid power in watts. Positive = importing from grid, negative = exporting to grid.
       required: true
       selector:
         number:
           min: -100000
           max: 100000
           unit_of_measurement: W
-    p_pv:
+    power_pv:
       name: PV power (W)
       description: Current PV generation in watts (optional).
       required: false
@@ -33,11 +31,9 @@ update_grid_power:
           min: 0
           max: 100000
           unit_of_measurement: W
-    p_akku:
+    power_battery:
       name: Battery power (W)
-      description: >
-        Current battery power in watts. Positive = charging,
-        negative = discharging (optional).
+      description: Current battery power in watts. Positive = charging, negative = discharging (optional).
       required: false
       selector:
         number:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -313,7 +313,7 @@ async def test_update_grid_power_p_grid_only(hass: HomeAssistant) -> None:
         await hass.services.async_call(
             DOMAIN,
             "update_grid_power",
-            {"device_id": device.id, "p_grid": 500.0},
+            {"device_id": device.id, "power_grid": 500.0},
             blocking=True,
         )
 
@@ -332,7 +332,7 @@ async def test_update_grid_power_all_fields(hass: HomeAssistant) -> None:
         await hass.services.async_call(
             DOMAIN,
             "update_grid_power",
-            {"device_id": device.id, "p_grid": -200.0, "p_pv": 1400.0, "p_akku": 0.0},
+            {"device_id": device.id, "power_grid": -200.0, "power_pv": 1400.0, "power_akku": 0.0},
             blocking=True,
         )
 
@@ -351,7 +351,7 @@ async def test_update_grid_power_leading_slash_topic(hass: HomeAssistant) -> Non
         await hass.services.async_call(
             DOMAIN,
             "update_grid_power",
-            {"device_id": device.id, "p_grid": 0.0},
+            {"device_id": device.id, "power_grid": 0.0},
             blocking=True,
         )
 
@@ -373,7 +373,7 @@ async def test_update_grid_power_unknown_device_logs_error(
         await hass.services.async_call(
             DOMAIN,
             "update_grid_power",
-            {"device_id": "nonexistent-id", "p_grid": 500.0},
+            {"device_id": "nonexistent-id", "power_grid": 500.0},
             blocking=True,
         )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -296,3 +296,86 @@ async def test_service_device_without_matching_entry_logs_error(
 
     mock_pub.assert_not_called()
     assert device.id in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# update_grid_power service
+# ---------------------------------------------------------------------------
+
+
+async def test_update_grid_power_p_grid_only(hass: HomeAssistant) -> None:
+    """Only p_grid publishes a minimal JSON payload."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "update_grid_power",
+            {"device_id": device.id, "p_grid": 500.0},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(
+        hass, "go-eCharger/072246/ids/set", '{"pGrid": 500.0}'
+    )
+
+
+async def test_update_grid_power_all_fields(hass: HomeAssistant) -> None:
+    """All three power values are included in the payload when provided."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "update_grid_power",
+            {"device_id": device.id, "p_grid": -200.0, "p_pv": 1400.0, "p_akku": 0.0},
+            blocking=True,
+        )
+
+    import json as _json
+    payload = _json.loads(mock_pub.call_args[0][2])
+    assert payload == {"pGrid": -200.0, "pPv": 1400.0, "pAkku": 0.0}
+
+
+async def test_update_grid_power_leading_slash_topic(hass: HomeAssistant) -> None:
+    """Leading slash in device topic is preserved."""
+    device = await _register_service_and_device(hass, "/go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "update_grid_power",
+            {"device_id": device.id, "p_grid": 0.0},
+            blocking=True,
+        )
+
+    assert mock_pub.call_args[0][1] == "/go-eCharger/072246/ids/set"
+
+
+async def test_update_grid_power_unknown_device_logs_error(
+    hass: HomeAssistant, caplog
+) -> None:
+    """An unknown device_id logs an error and does not publish."""
+    await async_setup(hass, {})
+
+    with (
+        patch(
+            "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+        ) as mock_pub,
+        caplog.at_level(logging.ERROR),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "update_grid_power",
+            {"device_id": "nonexistent-id", "p_grid": 500.0},
+            blocking=True,
+        )
+
+    mock_pub.assert_not_called()
+    assert "nonexistent-id" in caplog.text

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -332,7 +332,7 @@ async def test_update_grid_power_all_fields(hass: HomeAssistant) -> None:
         await hass.services.async_call(
             DOMAIN,
             "update_grid_power",
-            {"device_id": device.id, "power_grid": -200.0, "power_pv": 1400.0, "power_akku": 0.0},
+            {"device_id": device.id, "power_grid": -200.0, "power_pv": 1400.0, "power_battery": 0.0},
             blocking=True,
         )
 


### PR DESCRIPTION
Closes #101, related to #15

## Problem

The wallbox requires real-time grid power data (`ids` API key) for PV surplus charging and zero feed-in control. Until now users had to write manual `mqtt.publish` automations with hand-crafted JSON payloads.

## Solution

New service `goecharger_mqtt.update_grid_power` with fields:

| Field | Required | Description |
|-------|----------|-------------|
| `device_id` | yes | Target wallbox |
| `p_grid` | yes | Grid power in W (positive = import, negative = export) |
| `p_pv` | no | PV generation in W |
| `p_akku` | no | Battery power in W (positive = charging) |

Publishes `{"pGrid": X, "pPv": Y, "pAkku": Z}` to `<topic>/ids/set`.

**Important:** The wallbox does not stop automatically when updates cease - the service must be called every <=5 s from an automation while surplus or zero feed-in control is active.

**Prerequisite:** Since firmware 051.5 the wallbox has a `mcr` key (MQTT readonly mode). It must be set to `false` to allow MQTT writes. Use the HTTP API to disable it once: `GET /api/set?mcr=false`

## Example automation

```yaml
automation:
  trigger:
    platform: time_pattern
    seconds: "/5"
  action:
    service: goecharger_mqtt.update_grid_power
    data:
      device_id: !input wallbox_device
      p_grid: "{{ states('sensor.grid_power') | float }}"
      p_pv: "{{ states('sensor.pv_power') | float }}"
```

## Test plan

- [x] 4 new unit tests (p_grid only, all fields, topic variants, unknown device)
- [x] 298 tests pass
- [ ] Verify service appears in HA developer tools after integration reload
- [ ] Verify wallbox receives correct JSON on `ids/set` topic (confirmed working in #101)