### PR TITLE
Abort config flow with clear error when MQTT is not configured

### DIFF
--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.components import mqtt
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
@@ -131,6 +132,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
+        if not await mqtt.async_wait_for_mqtt_client(self.hass):
+            return self.async_abort(reason="mqtt_not_available")
+
         if user_input is None:
             return self.async_show_form(
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA

--- a/custom_components/goecharger_mqtt/strings.json
+++ b/custom_components/goecharger_mqtt/strings.json
@@ -27,6 +27,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "mqtt_not_available": "The MQTT integration is not available. Please set up MQTT first.",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   }

--- a/custom_components/goecharger_mqtt/translations/de.json
+++ b/custom_components/goecharger_mqtt/translations/de.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert"
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "mqtt_not_available": "Die MQTT-Integration ist nicht verfügbar. Bitte richte zuerst MQTT ein."
     },
     "flow_title": "{name}",
     "error": {

--- a/custom_components/goecharger_mqtt/translations/en.json
+++ b/custom_components/goecharger_mqtt/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "mqtt_not_available": "The MQTT integration is not available. Please set up MQTT first."
     },
     "flow_title": "{name}",
     "error": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the go-eCharger (MQTT) config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -16,6 +16,12 @@ from custom_components.goecharger_mqtt.const import (
     DOMAIN,
 )
 
+MQTT_AVAILABLE = patch(
+    "custom_components.goecharger_mqtt.config_flow.mqtt.async_wait_for_mqtt_client",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+
 try:
     from homeassistant.components.mqtt import MqttServiceInfo
 except ImportError:
@@ -29,13 +35,15 @@ except ImportError:
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test manual setup with a leading-slash topic."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with MQTT_AVAILABLE:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] is None
 
     with (
+        MQTT_AVAILABLE,
         patch(
             "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
             return_value=True,
@@ -61,11 +69,13 @@ async def test_form(hass: HomeAssistant) -> None:
 
 async def test_form_without_leading_slash(hass: HomeAssistant) -> None:
     """Test manual setup with a topic that has no leading slash."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with MQTT_AVAILABLE:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
     with (
+        MQTT_AVAILABLE,
         patch(
             "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
             return_value=True,
@@ -86,15 +96,34 @@ async def test_form_without_leading_slash(hass: HomeAssistant) -> None:
     }
 
 
+async def test_user_step_aborts_when_mqtt_unavailable(hass: HomeAssistant) -> None:
+    """Initiating the user flow without MQTT configured aborts with mqtt_not_available."""
+    with patch(
+        "custom_components.goecharger_mqtt.config_flow.mqtt.async_wait_for_mqtt_client",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "mqtt_not_available"
+
+
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with MQTT_AVAILABLE:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
-    with patch(
+    with (
+        MQTT_AVAILABLE,
+        patch(
         "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
         side_effect=CannotConnectError,
+        ),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -107,13 +136,17 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
 async def test_form_unknown_error(hass: HomeAssistant) -> None:
     """Test we handle unexpected errors."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with MQTT_AVAILABLE:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
-    with patch(
-        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
-        side_effect=Exception("boom"),
+    with (
+        MQTT_AVAILABLE,
+        patch(
+            "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+            side_effect=Exception("boom"),
+        ),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -242,6 +275,7 @@ async def test_mqtt_discovery_invalid_serial_aborts(hass: HomeAssistant) -> None
 async def test_form_duplicate_aborts(hass: HomeAssistant) -> None:
     """Manual setup with an already-configured serial number is aborted."""
     with (
+        MQTT_AVAILABLE,
         patch(
             "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
             return_value=True,
@@ -257,9 +291,12 @@ async def test_form_duplicate_aborts(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    with patch(
-        "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
-        return_value=True,
+    with (
+        MQTT_AVAILABLE,
+        patch(
+            "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
+            return_value=True,
+        ),
     ):
         result2 = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -315,11 +352,13 @@ async def test_mqtt_discovery_duplicate_aborts(hass: HomeAssistant) -> None:
 
 async def test_form_11kw_charging_power_stored(hass: HomeAssistant) -> None:
     """Selecting 11 kW stores the correct charging_power in config entry data."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with MQTT_AVAILABLE:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
     with (
+        MQTT_AVAILABLE,
         patch(
             "custom_components.goecharger_mqtt.config_flow.PlaceholderHub.validate_device_topic",
             return_value=True,


### PR DESCRIPTION
Fixes #1

## Problem

When users add the go-eCharger (MQTT) integration without having set up the MQTT integration first, the component silently fails while trying to access MQTT internals — no visible error, no explanation.

## Fix

`async_step_user` now calls `mqtt.async_wait_for_mqtt_client()` before doing anything else. If MQTT is not available, the flow aborts immediately with reason `mqtt_not_available` and shows a human-readable message in English and German:

> *The MQTT integration is not available. Please set up MQTT first.*

## Changes

- `config_flow.py`: import `mqtt`, add early-abort guard in `async_step_user`
- `strings.json` / `translations/en.json` / `translations/de.json`: add `mqtt_not_available` abort string
- `tests/test_config_flow.py`: mock `mqtt.async_wait_for_mqtt_client` in all user-flow tests; add `test_user_step_aborts_when_mqtt_unavailable`

All 299 tests pass.