### PR TITLE
Set charging power from /var payload during MQTT auto-discovery

### DIFF
--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -88,6 +88,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize flow."""
         self._topic = None
+        self._charging_power = CHARGING_POWER_22KW
 
     async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> FlowResult:
         """Handle a flow initialized by MQTT discovery."""
@@ -102,6 +103,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not serial_number.isnumeric():
             return self.async_abort(reason="invalid_discovery_info")
+
+        self._charging_power = (
+            CHARGING_POWER_11KW
+            if str(discovery_info.payload).strip() == "11"
+            else CHARGING_POWER_22KW
+        )
 
         await self.async_set_unique_id(serial_number)
         self._abort_if_unique_id_configured()
@@ -119,7 +126,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return self.async_create_entry(
                 title=name,
-                data={CONF_TOPIC: self._topic},
+                data={
+                    CONF_TOPIC: self._topic,
+                    CONF_CHARGING_POWER: self._charging_power,
+                },
             )
 
         self._set_confirm_only()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -187,7 +187,10 @@ async def test_mqtt_discovery_with_leading_slash(hass: HomeAssistant) -> None:
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
     assert result2["title"] == "go-eCharger 072246"
-    assert result2["data"] == {"topic": "/go-eCharger/072246"}
+    assert result2["data"] == {
+        "topic": "/go-eCharger/072246",
+        CONF_CHARGING_POWER: CHARGING_POWER_22KW,
+    }
 
 
 async def test_mqtt_discovery_without_leading_slash(hass: HomeAssistant) -> None:
@@ -214,7 +217,82 @@ async def test_mqtt_discovery_without_leading_slash(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
     assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["data"] == {"topic": "go-eCharger/072246"}
+    assert result2["data"] == {
+        "topic": "go-eCharger/072246",
+        CONF_CHARGING_POWER: CHARGING_POWER_22KW,
+    }
+
+
+async def test_mqtt_discovery_payload_11_sets_11kw(hass: HomeAssistant) -> None:
+    """Discovery with payload '11' stores 11 kW charging power."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="go-eCharger/072246/var",
+            payload="11",
+            qos=0,
+            retain=False,
+            subscribed_topic="go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    with patch(
+        "custom_components.goecharger_mqtt.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_CHARGING_POWER] == CHARGING_POWER_11KW
+
+
+async def test_mqtt_discovery_payload_22_sets_22kw(hass: HomeAssistant) -> None:
+    """Discovery with payload '22' stores 22 kW charging power."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="go-eCharger/072246/var",
+            payload="22",
+            qos=0,
+            retain=False,
+            subscribed_topic="go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    with patch(
+        "custom_components.goecharger_mqtt.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_CHARGING_POWER] == CHARGING_POWER_22KW
+
+
+async def test_mqtt_discovery_unknown_payload_falls_back_to_22kw(hass: HomeAssistant) -> None:
+    """Discovery with an unexpected payload falls back to 22 kW."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "mqtt"},
+        data=MqttServiceInfo(
+            topic="go-eCharger/072246/var",
+            payload="99",
+            qos=0,
+            retain=False,
+            subscribed_topic="go-eCharger/+/var",
+            timestamp=None,
+        ),
+    )
+    with patch(
+        "custom_components.goecharger_mqtt.async_setup_entry", return_value=True
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_CHARGING_POWER] == CHARGING_POWER_22KW
 
 
 async def test_reconfigure_updates_topic(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- `async_step_mqtt` parses `discovery_info.payload`: `"11"` → `CHARGING_POWER_11KW`, alles andere → `CHARGING_POWER_22KW` (Fallback)
- `async_step_discovery_confirm` schreibt `CONF_CHARGING_POWER` jetzt ins Config-Entry — bisher fehlte der Key bei auto-discovery komplett
- Drei neue Tests: payload `"11"`, `"22"`, unbekannter Wert

## Test plan

- [ ] `pytest tests/test_config_flow.py` — 17 Tests grün
- [ ] Manuelle Discovery mit 11-kW-Gerät: `/var`-Topic sendet `11`, Entity-Limit = 16 A
- [ ] Manuelle Discovery mit 22-kW-Gerät: `/var`-Topic sendet `22`, Entity-Limit = 32 A
- [ ] Discovery mit unerwartetem Payload → Fallback 22 kW