### PR TITLE
Add `psm` select entity to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ This manual method achieves the same result as the HACS installation but require
 | Key | Friendly name | Category | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ------------------- | --------- | ------------------ |
 | `lmo` | Logic mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
+| `psm` | Phase switch mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `ust` | Cable unlock mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `frc` | Force state | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `trx` | Transaction | `config` | :heavy_check_mark: | :heavy_check_mark: | |


### PR DESCRIPTION
Closes #93

The `psm` (Phase switch mode) select entity was introduced in #92 to fix #89 but was never added to the README's Select entities table.

This patch adds the missing row.