### PR TITLE
[BREAKING] Expose bac and sdp as select entities with four lock modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,9 @@ This manual method achieves the same result as the HACS installation but require
 
 | Key | Friendly name | Category | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ------------------- | --------- | ------------------ |
-| `bac` | Allow current change by button | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `ara` | Automatic stop mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `wen` | WiFi enabled | `config` | :white_large_square: | :white_large_square: | [^1] |
 | `tse` | Time server enabled | `config` | :white_large_square: | :white_large_square: | [^1] |
-| `sdp` | Button allow force change | `config` | :white_large_square: | :white_large_square: | [^1] |
 | `nmo` | Norway mode | `config` | :white_large_square: | :white_large_square: | [^1] |
 | `lse` | LED off on standby | `config` | :white_large_square: | :white_large_square: | [^1] |
 | `awe` | Awattar mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
@@ -317,6 +315,8 @@ This manual method achieves the same result as the HACS installation but require
 
 | Key | Friendly name | Category | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ------------------- | --------- | ------------------ |
+| `bac` | Button allow current change | `config` | :heavy_check_mark: | :heavy_check_mark: | Values: `always_lock` / `lock_when_car_connected` / `lock_when_charging` / `never_lock` |
+| `sdp` | Button allow force change | `config` | :heavy_check_mark: | :heavy_check_mark: | Values: `always_lock` / `lock_when_car_connected` / `lock_when_charging` / `never_lock` |
 | `lmo` | Logic mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `psm` | Phase switch mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |
 | `ust` | Cable unlock mode | `config` | :heavy_check_mark: | :heavy_check_mark: | |

--- a/custom_components/goecharger_mqtt/definitions/select.py
+++ b/custom_components/goecharger_mqtt/definitions/select.py
@@ -51,8 +51,9 @@ SELECTS: tuple[GoEChargerSelectEntityDescription, ...] = (
         attribute="sdp",
         entity_category=EntityCategory.CONFIG,
         device_class=None,
-        entity_registry_enabled_default=True,
-        disabled=False,
+        entity_registry_enabled_default=False,
+        disabled=True,
+        disabled_reason="Not exposed via MQTT in firmware 060.5",
     ),
     GoEChargerSelectEntityDescription(
         key="lmo",

--- a/custom_components/goecharger_mqtt/definitions/select.py
+++ b/custom_components/goecharger_mqtt/definitions/select.py
@@ -23,18 +23,16 @@ class GoEChargerSelectEntityDescription(
     domain: str = "select"
 
 
-_BUTTON_LOCK_OPTIONS = {
-    "0": "always_lock",
-    "1": "lock_when_car_connected",
-    "2": "lock_when_charging",
-    "3": "never_lock",
-}
-
 SELECTS: tuple[GoEChargerSelectEntityDescription, ...] = (
     GoEChargerSelectEntityDescription(
         key="bac",
         name="Button allow current change",
-        legacy_options=_BUTTON_LOCK_OPTIONS,
+        legacy_options={
+            "0": "always_lock",
+            "1": "lock_when_car_connected",
+            "2": "lock_when_charging",
+            "3": "never_lock",
+        },
         attribute="bac",
         entity_category=EntityCategory.CONFIG,
         device_class=None,
@@ -44,7 +42,12 @@ SELECTS: tuple[GoEChargerSelectEntityDescription, ...] = (
     GoEChargerSelectEntityDescription(
         key="sdp",
         name="Button allow force change",
-        legacy_options=_BUTTON_LOCK_OPTIONS,
+        legacy_options={
+            "0": "always_lock",
+            "1": "lock_when_car_connected",
+            "2": "lock_when_charging",
+            "3": "never_lock",
+        },
         attribute="sdp",
         entity_category=EntityCategory.CONFIG,
         device_class=None,

--- a/custom_components/goecharger_mqtt/definitions/select.py
+++ b/custom_components/goecharger_mqtt/definitions/select.py
@@ -28,8 +28,6 @@ _BUTTON_LOCK_OPTIONS = {
     "1": "lock_when_car_connected",
     "2": "lock_when_charging",
     "3": "never_lock",
-    "false": "always_lock",  # compat: pre-0.55 firmware sent boolean
-    "true": "never_lock",    # compat: pre-0.55 firmware sent boolean
 }
 
 SELECTS: tuple[GoEChargerSelectEntityDescription, ...] = (

--- a/custom_components/goecharger_mqtt/definitions/select.py
+++ b/custom_components/goecharger_mqtt/definitions/select.py
@@ -23,7 +23,36 @@ class GoEChargerSelectEntityDescription(
     domain: str = "select"
 
 
+_BUTTON_LOCK_OPTIONS = {
+    "0": "always_lock",
+    "1": "lock_when_car_connected",
+    "2": "lock_when_charging",
+    "3": "never_lock",
+    "false": "always_lock",  # compat: pre-0.55 firmware sent boolean
+    "true": "never_lock",    # compat: pre-0.55 firmware sent boolean
+}
+
 SELECTS: tuple[GoEChargerSelectEntityDescription, ...] = (
+    GoEChargerSelectEntityDescription(
+        key="bac",
+        name="Button allow current change",
+        legacy_options=_BUTTON_LOCK_OPTIONS,
+        attribute="bac",
+        entity_category=EntityCategory.CONFIG,
+        device_class=None,
+        entity_registry_enabled_default=True,
+        disabled=False,
+    ),
+    GoEChargerSelectEntityDescription(
+        key="sdp",
+        name="Button allow force change",
+        legacy_options=_BUTTON_LOCK_OPTIONS,
+        attribute="sdp",
+        entity_category=EntityCategory.CONFIG,
+        device_class=None,
+        entity_registry_enabled_default=True,
+        disabled=False,
+    ),
     GoEChargerSelectEntityDescription(
         key="lmo",
         name="Logic mode",

--- a/custom_components/goecharger_mqtt/definitions/switch.py
+++ b/custom_components/goecharger_mqtt/definitions/switch.py
@@ -27,14 +27,6 @@ class GoEChargerSwitchEntityDescription(
 
 SWITCHES: tuple[GoEChargerSwitchEntityDescription, ...] = (
     GoEChargerSwitchEntityDescription(
-        key="bac",
-        name="Allow current change by button",
-        entity_category=EntityCategory.CONFIG,
-        device_class=None,
-        entity_registry_enabled_default=True,
-        disabled=False,
-    ),
-    GoEChargerSwitchEntityDescription(
         key="ara",
         name="Automatic stop mode",
         entity_category=EntityCategory.CONFIG,
@@ -54,15 +46,6 @@ SWITCHES: tuple[GoEChargerSwitchEntityDescription, ...] = (
     GoEChargerSwitchEntityDescription(
         key="tse",
         name="Time server enabled",
-        entity_category=EntityCategory.CONFIG,
-        device_class=None,
-        entity_registry_enabled_default=False,
-        disabled=True,
-        disabled_reason="Not exposed via MQTT in firmware 053.1",
-    ),
-    GoEChargerSwitchEntityDescription(
-        key="sdp",
-        name="Button allow force change",
         entity_category=EntityCategory.CONFIG,
         device_class=None,
         entity_registry_enabled_default=False,

--- a/custom_components/goecharger_mqtt/select.py
+++ b/custom_components/goecharger_mqtt/select.py
@@ -40,7 +40,7 @@ class GoEChargerSelect(GoEChargerEntity, SelectEntity):
         super().__init__(config_entry, description)
 
         self.entity_description = description
-        self._attr_options = list(dict.fromkeys(description.legacy_options.values()))
+        self._attr_options = list(description.legacy_options.values())
         self._attr_current_option = None
 
     def key_from_option(self, option: str):

--- a/custom_components/goecharger_mqtt/select.py
+++ b/custom_components/goecharger_mqtt/select.py
@@ -40,7 +40,7 @@ class GoEChargerSelect(GoEChargerEntity, SelectEntity):
         super().__init__(config_entry, description)
 
         self.entity_description = description
-        self._attr_options = list(description.legacy_options.values())
+        self._attr_options = list(dict.fromkeys(description.legacy_options.values()))
         self._attr_current_option = None
 
     def key_from_option(self, option: str):

--- a/custom_components/goecharger_mqtt/translations/de.json
+++ b/custom_components/goecharger_mqtt/translations/de.json
@@ -31,6 +31,26 @@
     }
   },
   "entity": {
+    "select": {
+      "bac": {
+        "name": "Tasten-Stromänderungssperre",
+        "state": {
+          "always_lock": "Immer gesperrt",
+          "lock_when_car_connected": "Gesperrt wenn Fahrzeug verbunden",
+          "lock_when_charging": "Gesperrt beim Laden",
+          "never_lock": "Nie gesperrt"
+        }
+      },
+      "sdp": {
+        "name": "Tasten-Zwangszustandssperre",
+        "state": {
+          "always_lock": "Immer gesperrt",
+          "lock_when_car_connected": "Gesperrt wenn Fahrzeug verbunden",
+          "lock_when_charging": "Gesperrt beim Laden",
+          "never_lock": "Nie gesperrt"
+        }
+      }
+    },
     "sensor": {
       "nrg_0": { "name": "Spannung L1" },
       "nrg_1": { "name": "Spannung L2" },

--- a/custom_components/goecharger_mqtt/translations/en.json
+++ b/custom_components/goecharger_mqtt/translations/en.json
@@ -31,6 +31,26 @@
     }
   },
   "entity": {
+    "select": {
+      "bac": {
+        "name": "Button allow current change",
+        "state": {
+          "always_lock": "Always lock",
+          "lock_when_car_connected": "Lock when car connected",
+          "lock_when_charging": "Lock when charging",
+          "never_lock": "Never lock"
+        }
+      },
+      "sdp": {
+        "name": "Button allow force change",
+        "state": {
+          "always_lock": "Always lock",
+          "lock_when_car_connected": "Lock when car connected",
+          "lock_when_charging": "Lock when charging",
+          "never_lock": "Never lock"
+        }
+      }
+    },
     "sensor": {
       "nrg_0": { "name": "Voltage L1" },
       "nrg_1": { "name": "Voltage L2" },

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -38,7 +38,7 @@ _TOPIC = "go-eCharger/072246"
     [
         # attribute="" (default) — must fall back to "0" to keep pre-#200 unique_id format
         ("go-eCharger/072246", "ate", "sensor", "", "072246-sensor-ate-0"),
-        ("go-eCharger/072246", "bac", "switch", "", "072246-switch-bac-0"),
+        ("go-eCharger/072246", "bac", "select", "bac", "072246-select-bac-bac"),
         ("go-eCharger/072246", "amp", "number", "", "072246-number-amp-0"),
         ("go-eCharger/072246", "lmo", "select", "", "072246-select-lmo-0"),
         (
@@ -335,18 +335,18 @@ _ALL_ENTITIES = [
     ("psh", "number", "", "072246-number-psh-0"),
     ("po", "number", "", "072246-number-po-0"),
     ("zfo", "number", "", "072246-number-zfo-0"),
-    # --- select (5 entries) ---
+    # --- select (7 entries) ---
+    ("bac", "select", "bac", "072246-select-bac-bac"),
+    ("sdp", "select", "sdp", "072246-select-sdp-sdp"),
     ("lmo", "select", "", "072246-select-lmo-0"),
     ("ust", "select", "ust", "072246-select-ust-ust"),
     ("frc", "select", "frc", "072246-select-frc-frc"),
     ("trx", "select", "trx", "072246-select-trx-trx"),
     ("psm", "select", "psm", "072246-select-psm-psm"),
-    # --- switch (19 entries) ---
-    ("bac", "switch", "", "072246-switch-bac-0"),
+    # --- switch (17 entries) ---
     ("ara", "switch", "", "072246-switch-ara-0"),
     ("wen", "switch", "", "072246-switch-wen-0"),
     ("tse", "switch", "", "072246-switch-tse-0"),
-    ("sdp", "switch", "", "072246-switch-sdp-0"),
     ("nmo", "switch", "", "072246-switch-nmo-0"),
     ("lse", "switch", "", "072246-switch-lse-0"),
     ("awe", "switch", "", "072246-switch-awe-0"),


### PR DESCRIPTION
Closes #88

Firmware 0.55 changed `bac` (button allow current change) and `sdp` (button allow force change) from booleans to `uint8_t` with four states:

| Value | Meaning |
|-------|---------|
| `0` | Always lock |
| `1` | Lock when car connected |
| `2` | Lock when charging |
| `3` | Never lock |

Both keys are now exposed as `select` entities. `sdp` was previously disabled; it is enabled here for the first time. Options use slugs with translations for `en` and `de`.