### PR TITLE
[BREAKING] Remove duplicate ama sensor entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This manual method achieves the same result as the HACS installation but require
 | Key | Friendly name | Category | Unit | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ---- | ------------------- | --------- | ------------------ |
 | `+/result` | Last set config key result | `config` |  | :heavy_check_mark: | :heavy_check_mark: | |
-| `ama` | Maximum current limit | `config` | A | :heavy_check_mark: | :heavy_check_mark: | |
+
 | `ate` | Automatic stop energy | `config` | Wh | :heavy_check_mark: | :heavy_check_mark: | |
 | `att` | Automatic stop time | `config` | s | :heavy_check_mark: | :heavy_check_mark: | |
 | `awc` | Awattar country | `config` |  | :white_large_square: | :white_large_square: | [^1] |

--- a/custom_components/goecharger_mqtt/definitions/sensor.py
+++ b/custom_components/goecharger_mqtt/definitions/sensor.py
@@ -216,16 +216,7 @@ SENSORS: tuple[GoEChargerSensorEntityDescription, ...] = (
         entity_registry_enabled_default=True,
         disabled=False,
     ),
-    GoEChargerSensorEntityDescription(
-        key="ama",
-        name="Maximum current limit",
-        entity_category=None,
-        device_class=SensorDeviceClass.CURRENT,
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_registry_enabled_default=True,
-        disabled=False,
-    ),
+
     GoEChargerSensorEntityDescription(
         key="ate",
         name="Automatic stop energy",

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -117,7 +117,7 @@ async def test_entity_unique_id_stable(
 _ALL_ENTITIES = [
     # --- sensor (195 entries) ---
     ("+/result", "sensor", "", "072246-sensor-+/result-0"),
-    ("ama", "sensor", "", "072246-sensor-ama-0"),
+
     ("ate", "sensor", "", "072246-sensor-ate-0"),
     ("att", "sensor", "", "072246-sensor-att-0"),
     ("awc", "sensor", "", "072246-sensor-awc-0"),


### PR DESCRIPTION
Closes #100

`ama` (Maximum current limit) is already exposed as a configurable **number** entity. The additional **sensor** entity was redundant and confusing — especially since the README showed it with a mangled column layout (unit `A` in the "Enabled per default" column).