### PR TITLE
Add pre-commit and mypy CI jobs

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,22 @@
+name: mypy
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          pip install mypy
+          pip install -r requirements.test.txt
+      - name: Run mypy
+        run: mypy custom_components/goecharger_mqtt

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,17 @@
+name: pre-commit
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -114,6 +114,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator.async_set_update_error(Exception("Heartbeat timeout"))
 
     unsub = await mqtt.async_subscribe(hass, f"{topic}/utc", _on_heartbeat, 1)
+
     def _cancel_timeout() -> None:
         if _timeout_handle:
             _timeout_handle.cancel()

--- a/custom_components/goecharger_mqtt/config_flow.py
+++ b/custom_components/goecharger_mqtt/config_flow.py
@@ -90,7 +90,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._topic: str | None = None
         self._charging_power = CHARGING_POWER_22KW
 
-    async def async_step_mqtt(self, discovery_info: MqttServiceInfo) -> ConfigFlowResult:
+    async def async_step_mqtt(
+        self, discovery_info: MqttServiceInfo
+    ) -> ConfigFlowResult:
         """Handle a flow initialized by MQTT discovery."""
         subscribed_topic = discovery_info.subscribed_topic
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ combine_as_imports = true
 
 [mypy]
 python_version = 3.13
-ignore_errors = true
 follow_imports = silent
 ignore_missing_imports = true
 warn_incomplete_stub = true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pre-commit.yaml`: runs all pre-commit hooks (ruff-check, ruff-format, codespell, prettier) on every push/PR — keeps CI and local dev in sync automatically
- Add `.github/workflows/mypy.yaml`: runs mypy type checks against `custom_components/goecharger_mqtt` on every push/PR
- Remove `ignore_errors = true` from `[mypy]` in `setup.cfg` — this flag silently discarded all mypy output, making the config a no-op

## Background

HA-Core runs equivalent jobs (`prek` for pre-commit, `mypy` with 4 workers) on every PR. Popular custom components (adaptive_lighting, hass-blueprint) use the same pre-commit-in-CI pattern. Until now, both ruff and mypy only ran locally via pre-commit with no CI enforcement.

## Test plan

- [ ] `pre-commit` job passes on this PR
- [ ] `mypy` job passes on this PR
- [ ] Existing `hassfest`, `hacs`, `yamllint`, `pytest` jobs unaffected