### PR TITLE
Fix psm sensor reporting raw codes instead of slugs

### DIFF
--- a/custom_components/goecharger_mqtt/definitions/sensor.py
+++ b/custom_components/goecharger_mqtt/definitions/sensor.py
@@ -204,6 +204,19 @@ def to_code_slug(value, attribute) -> str:
         return str(value)
 
 
+def to_psm_slug(value, unused) -> str:
+    """Map a raw psm MQTT status code to a slug.
+
+    Unlike to_code_slug(), the lookup key is hardcoded instead of taken from
+    attribute, since attribute must stay "" here to keep this sensor's
+    unique_id stable (see #227).
+    """
+    try:
+        return _CODE_STATES["psm"].get(int(value), str(value))
+    except (ValueError, KeyError):
+        return str(value)
+
+
 SENSORS: tuple[GoEChargerSensorEntityDescription, ...] = (
     GoEChargerSensorEntityDescription(
         key="+/result",
@@ -2066,7 +2079,7 @@ SENSORS: tuple[GoEChargerSensorEntityDescription, ...] = (
     GoEChargerSensorEntityDescription(
         key="psm",
         name="Phase switch mode",
-        state=to_code_slug,
+        state=to_psm_slug,
         entity_category=None,
         icon="mdi:speedometer",
         device_class=SensorDeviceClass.ENUM,

--- a/tests/test_sensor_definitions.py
+++ b/tests/test_sensor_definitions.py
@@ -1,0 +1,27 @@
+"""Verify raw MQTT status codes are mapped to slugs (Closes: #227)."""
+
+import pytest
+
+from custom_components.goecharger_mqtt.definitions.sensor import (
+    to_code_slug,
+    to_psm_slug,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0", "auto"),
+        ("1", "one_phase"),
+        ("2", "three_phases"),
+        ("99", "99"),  # unknown code falls back to raw value
+    ],
+)
+def test_to_psm_slug(value, expected) -> None:
+    """Psm must resolve slugs regardless of the (empty) attribute passed in."""
+    assert to_psm_slug(value, "") == expected
+
+
+def test_to_code_slug_with_empty_attribute_falls_back_to_raw_value() -> None:
+    """Documents why psm can't use to_code_slug with its default attribute=""."""
+    assert to_code_slug("2", "") == "2"


### PR DESCRIPTION
## Summary
- `psm` was the only `state=to_code_slug` sensor without an explicit `attribute`, so `to_code_slug` looked up `_CODE_STATES[""]`, missed, and silently fell back to the raw MQTT code (`0`/`1`/`2`) instead of the slug (`auto`/`one_phase`/`three_phases`).
- Simply setting `attribute="psm"` (the fix tried in #200) changes the entity's `unique_id` from `psm-0` to `psm-psm`, which creates duplicate entities for existing installs on upgrade — that's why it was reverted in `dac6318`.
- Added `to_psm_slug()`, a small dedicated mapper that hardcodes the `"psm"` lookup key instead of reading it from `attribute`, so the state is decoded correctly while `attribute`/`unique_id` stay untouched.

Closes #227

## Test plan
- [x] `pytest` (full suite, 306 passed)
- [x] New `tests/test_sensor_definitions.py` covers `to_psm_slug` mapping `0/1/2` → `auto/one_phase/three_phases` and unknown codes falling back to the raw value
- [x] `tests/test_entity_unique_id.py` still asserts `psm` sensor `unique_id` stays `072246-sensor-psm-0`
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` shows no new errors (2 pre-existing, unrelated errors in `config_flow.py`/`number.py`)