### PR TITLE
[BREAKING] Add button to clear energy limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ This manual method achieves the same result as the HACS installation but require
 | `frc` | Force state neutral | `config` | :white_large_square: | :heavy_check_mark: | |
 | `frc` | Force state dont charge | `config` | :white_large_square: | :heavy_check_mark: | |
 | `frc` | Force state charge | `config` | :white_large_square: | :heavy_check_mark: | |
+| `dwo` | Clear energy limit | `config` | :heavy_check_mark:  | :heavy_check_mark: | |
 
 ### Sensors
 
 | Key | Friendly name | Category | Unit | Enabled per default | Supported | Unsupported reason |
 | --- | ------------- | -------- | ---- | ------------------- | --------- | ------------------ |
 | `+/result` | Last set config key result | `config` |  | :heavy_check_mark: | :heavy_check_mark: | |
-
 | `ate` | Automatic stop energy | `config` | Wh | :heavy_check_mark: | :heavy_check_mark: | |
 | `att` | Automatic stop time | `config` | s | :heavy_check_mark: | :heavy_check_mark: | |
 | `awc` | Awattar country | `config` |  | :white_large_square: | :white_large_square: | [^1] |

--- a/custom_components/goecharger_mqtt/definitions/button.py
+++ b/custom_components/goecharger_mqtt/definitions/button.py
@@ -67,4 +67,14 @@ BUTTONS: tuple[GoEChargerButtonEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         disabled=False,
     ),
+    GoEChargerButtonEntityDescription(
+        key="dwo",
+        name="Clear energy limit",
+        payload_press="null",
+        entity_category=EntityCategory.CONFIG,
+        device_class=None,
+        icon="mdi:infinity",
+        entity_registry_enabled_default=True,
+        disabled=False,
+    ),
 )

--- a/custom_components/goecharger_mqtt/definitions/number.py
+++ b/custom_components/goecharger_mqtt/definitions/number.py
@@ -27,7 +27,6 @@ class GoEChargerNumberEntityDescription(
     """Number entity description for go-eCharger."""
 
     domain: str = "number"
-    treat_zero_as_null: bool = False
 
 
 NUMBERS: tuple[GoEChargerNumberEntityDescription, ...] = (
@@ -114,7 +113,6 @@ NUMBERS: tuple[GoEChargerNumberEntityDescription, ...] = (
         native_max_value=1000000,
         native_min_value=0,
         native_step=1,
-        treat_zero_as_null=True,
     ),
     GoEChargerNumberEntityDescription(
         key="lop",

--- a/custom_components/goecharger_mqtt/number.py
+++ b/custom_components/goecharger_mqtt/number.py
@@ -56,9 +56,7 @@ class GoEChargerNumber(GoEChargerEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        if value == 0 and self.entity_description.treat_zero_as_null:
-            await mqtt.async_publish(self.hass, f"{self._topic}/set", "null")
-        elif self.native_step == 1:
+        if self.native_step == 1:
             await mqtt.async_publish(self.hass, f"{self._topic}/set", int(value))
         else:
             await mqtt.async_publish(self.hass, f"{self._topic}/set", value)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,49 @@
+"""Test go-eCharger (MQTT) button entities."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.goecharger_mqtt.button import GoEChargerButton
+from custom_components.goecharger_mqtt.const import CONF_TOPIC, DOMAIN
+from custom_components.goecharger_mqtt.definitions.button import BUTTONS
+
+
+def _entity_for(hass, key: str, attribute: str = "") -> GoEChargerButton:
+    """Build a GoEChargerButton for the given definition key/attribute."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_TOPIC: "go-eCharger/072246"}, version=2
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
+    description = next(d for d in BUTTONS if d.key == key and d.attribute == attribute)
+    entity = GoEChargerButton(entry, description)
+    entity.hass = hass
+    return entity
+
+
+@pytest.mark.parametrize(
+    "key,attribute,expected_payload",
+    [
+        ("rst", "", "true"),
+        ("frc", "0", "0"),
+        ("frc", "1", "1"),
+        ("frc", "2", "2"),
+        ("dwo", "", "null"),
+    ],
+)
+async def test_button_publishes_payload_press(
+    hass, key, attribute, expected_payload
+) -> None:
+    """Pressing a button publishes its configured payload_press verbatim."""
+    entity = _entity_for(hass, key, attribute)
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await entity.async_press()
+
+    mock_pub.assert_called_once_with(
+        hass, f"go-eCharger/072246/{key}/set", expected_payload
+    )

--- a/tests/test_entity_unique_id.py
+++ b/tests/test_entity_unique_id.py
@@ -320,6 +320,7 @@ _ALL_ENTITIES = [
     ("frc", "button", "0", "072246-button-frc-0"),
     ("frc", "button", "1", "072246-button-frc-1"),
     ("frc", "button", "2", "072246-button-frc-2"),
+    ("dwo", "button", "", "072246-button-dwo-0"),
     # --- number (8 entries) ---
     ("ama", "number", "", "072246-number-ama-0"),
     ("amp", "number", "", "072246-number-amp-0"),

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,34 @@
+"""Test go-eCharger (MQTT) number entities."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.goecharger_mqtt.const import CONF_TOPIC, DOMAIN
+from custom_components.goecharger_mqtt.definitions.number import NUMBERS
+from custom_components.goecharger_mqtt.number import GoEChargerNumber
+
+
+def _entity_for(hass, key: str) -> GoEChargerNumber:
+    """Build a GoEChargerNumber for the given definition key."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_TOPIC: "go-eCharger/072246"}, version=2
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
+    description = next(d for d in NUMBERS if d.key == key)
+    entity = GoEChargerNumber(entry, description)
+    entity.hass = hass
+    return entity
+
+
+async def test_dwo_zero_publishes_numeric_zero_not_null(hass) -> None:
+    """dwo=0 now publishes 0 as-is; clearing the limit is the dedicated button's job."""
+    entity = _entity_for(hass, "dwo")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await entity.async_set_native_value(0)
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/dwo/set", 0)


### PR DESCRIPTION
Hello,

when I introduced the charging energy limit (key dwo) in PR #143 I chose to treat setting a value of 0 as removing the energy limit so that this functionality is present. However, since then I realized that this somewhat dirty workaround is not ideal as someone could assume the value of 0 meaning "Never charge" while with the current implementation it actually means "Always charge".

When using the Homeassistant MQTT Autodiscovery feature of go-e this problem is solved by adding a dedicated button for removing the energy limit instead of doing so via the number entity. This PR introduces such a button also for this integration and removes the old dirty workaround. I added the [BREAKING] tag because if someone was using this old workaround they have to switch to using the new button.

Best regards,
Triple-S