### PR TITLE
Truncate OCU firmware list to fit HA's 255 char state limit

### DIFF
--- a/custom_components/goecharger_mqtt/definitions/sensor.py
+++ b/custom_components/goecharger_mqtt/definitions/sensor.py
@@ -73,7 +73,18 @@ def json_array_to_csv(value, unused) -> str:
     if value == "null":
         return ""
 
-    return ", ".join(json.loads(value))
+    items = json.loads(value)
+    csv = ", ".join(items)
+    if len(csv) <= 255:
+        return csv
+
+    length = 0
+    for cutoff, item in enumerate(items):
+        length += len(item) + (2 if cutoff else 0)  # ", " separator
+        if length > 250:
+            break
+
+    return ", ".join(items[:cutoff]) + ", ..."
 
 
 def extract_item_from_array_to_float(value, key) -> float | None:

--- a/tests/test_sensor_definitions.py
+++ b/tests/test_sensor_definitions.py
@@ -1,8 +1,11 @@
 """Verify raw MQTT status codes are mapped to slugs (Closes: #227)."""
 
+import json
+
 import pytest
 
 from custom_components.goecharger_mqtt.definitions.sensor import (
+    json_array_to_csv,
     to_code_slug,
     to_psm_slug,
 )
@@ -25,3 +28,93 @@ def test_to_psm_slug(value, expected) -> None:
 def test_to_code_slug_with_empty_attribute_falls_back_to_raw_value() -> None:
     """Documents why psm can't use to_code_slug with its default attribute=""."""
     assert to_code_slug("2", "") == "2"
+
+
+def test_json_array_to_csv_with_null_value_returns_empty_string() -> None:
+    """The ocu sensor reports the literal string "null" when unset."""
+    assert json_array_to_csv("null", "") == ""
+
+
+def test_json_array_to_csv_joins_items_with_comma_and_space() -> None:
+    assert (
+        json_array_to_csv(json.dumps(["60.6 BETA", "60.5 BETA"]), "")
+        == "60.6 BETA, 60.5 BETA"
+    )
+
+
+def test_json_array_to_csv_leaves_short_lists_untouched() -> None:
+    """A CSV of 255 chars or less must not be truncated."""
+    items = [f"v{i}" for i in range(45)]  # joined length is 213 chars
+    value = json.dumps(items)
+    csv = json_array_to_csv(value, "")
+
+    assert len(csv) <= 255
+    assert csv == ", ".join(items)
+    assert not csv.endswith(", ...")
+
+
+def test_json_array_to_csv_truncates_lists_longer_than_255_chars() -> None:
+    """Reproduces the OTA firmware list from #231 that exceeds HA's 255 char state limit."""
+    items = [
+        "60.6 BETA",
+        "60.5 BETA",
+        "60.4 BETA",
+        "60.3 BETA",
+        "60.2 BETA",
+        "60.1 BETA",
+        "60.0 BETA",
+        "59.4",
+        "57.1 OUTDATED",
+        "V 57.0 OUTDATED",
+        "V 56.11 OUTDATED",
+        "V 56.9 OUTDATED",
+        "V 56.8 OUTDATED",
+        "V 56.2 OUTDATED",
+        "V 56.1 OUTDATED",
+        "V 055.8 OUTDATED",
+        "V 055.7 OUTDATED",
+        "V 055.5 OUTDATED",
+        "V 055.0 OUTDATED",
+    ]
+    full_csv = ", ".join(items)
+    assert len(full_csv) > 255  # sanity check: fixture must reproduce the bug
+
+    csv = json_array_to_csv(json.dumps(items), "")
+
+    assert len(csv) <= 255
+    assert csv.endswith(", ...")
+    # No version number may be cut in half: every entry before the ellipsis
+    # must be one of the original, complete items.
+    kept = csv[: -len(", ...")].split(", ")
+    assert kept == items[: len(kept)]
+    assert len(kept) < len(items)
+    # Newest firmware versions are listed first, so they must survive truncation.
+    assert csv.startswith("60.6 BETA, 60.5 BETA")
+
+
+def test_json_array_to_csv_stops_adding_items_once_250_chars_would_be_exceeded() -> None:
+    """The item that would push the string past 250 chars is dropped, not cut."""
+    # The 41 "aa" items alone join to 162 chars; adding the 100-char item
+    # would push the running total to 264, so it must be dropped whole.
+    items = ["aa"] * 41 + ["b" * 100]
+    value = json.dumps(items)
+    assert len(", ".join(items)) > 255  # sanity check: fixture must reproduce the bug
+
+    csv = json_array_to_csv(value, "")
+
+    assert csv == ", ".join(["aa"] * 41) + ", ..."
+    assert len(csv) <= 255
+
+
+def test_json_array_to_csv_truncates_exactly_at_the_255_char_boundary() -> None:
+    """A CSV of exactly 256 chars is the smallest input that must be truncated."""
+    items = ["a"] * 86  # 86 * "a" joined by ", " == 256 chars
+    value = json.dumps(items)
+    full_csv = ", ".join(items)
+    assert len(full_csv) == 256
+
+    csv = json_array_to_csv(value, "")
+
+    # 84 items join to exactly 250 chars, the most that still fits.
+    assert csv == ", ".join(["a"] * 84) + ", ..."
+    assert len(csv) == 255

--- a/tests/test_sensor_definitions.py
+++ b/tests/test_sensor_definitions.py
@@ -36,6 +36,7 @@ def test_json_array_to_csv_with_null_value_returns_empty_string() -> None:
 
 
 def test_json_array_to_csv_joins_items_with_comma_and_space() -> None:
+    """The CSV separator between items is ", "."""
     assert (
         json_array_to_csv(json.dumps(["60.6 BETA", "60.5 BETA"]), "")
         == "60.6 BETA, 60.5 BETA"
@@ -92,7 +93,7 @@ def test_json_array_to_csv_truncates_lists_longer_than_255_chars() -> None:
     assert csv.startswith("60.6 BETA, 60.5 BETA")
 
 
-def test_json_array_to_csv_stops_adding_items_once_250_chars_would_be_exceeded() -> None:
+def test_json_array_to_csv_drops_item_that_would_exceed_250_chars() -> None:
     """The item that would push the string past 250 chars is dropped, not cut."""
     # The 41 "aa" items alone join to 162 chars; adding the 100-char item
     # would push the running total to 264, so it must be dropped whole.


### PR DESCRIPTION
## Summary
- `ocu` (list of available firmware versions) can report a JSON array whose CSV rendering exceeds Home Assistant's 255 char state limit, spamming the core logger with "State ... is longer than 255, falling back to unknown".
- `json_array_to_csv` now keeps as many complete, comma-separated version numbers as fit into 250 chars and appends ", ..." if any were dropped. No version number is ever cut in half, and since the device lists newest versions first, they are the ones preserved.

Closes #231

## Test plan
- [x] Added unit tests in `tests/test_sensor_definitions.py` covering: null value, short/untouched lists, the exact firmware list from #231, an item dropped whole instead of split, and the exact 255/256 char boundary.