### PR TITLE
Fix set_config_key quoting of JSON null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,13 +369,15 @@ action:
 
 ### Service `goecharger_mqtt.set_config_key`
 
-Sets a config `key` to a `value`.
+Sets a config `key` to a `value` by publishing to `{topic}/{key}/set`.
 
 | Service data attribute    | Optional | Description                                                          |
 |---------------------------|----------|----------------------------------------------------------------------|
-| `serial_number`           |       no | The serial number of the go-e device                                 |
+| `device_id`               |       no | The go-eCharger device to configure                                  |
 | `key`                     |       no | The key of the config parameter you want to change                   |
 | `value`                   |       no | The new value                                                        |
+
+`value` is a string (or YAML `null`). Numeric values are published as-is. The strings `true`/`True` and `false`/`False` are published as lowercase booleans. `null`/`none` (and YAML `null`) are published as JSON `null` — required to clear nullable keys such as `trx`. Any other string is JSON-quoted.
 
 ## Tips and tricks
 

--- a/custom_components/goecharger_mqtt/__init__.py
+++ b/custom_components/goecharger_mqtt/__init__.py
@@ -44,7 +44,7 @@ SERVICE_SCHEMA_SET_CONFIG_KEY = vol.Schema(
     {
         vol.Required("device_id"): cv.string,
         vol.Required(ATTR_KEY): cv.string,
-        vol.Required(ATTR_VALUE): cv.string,
+        vol.Required(ATTR_VALUE): vol.Any(None, cv.string),
     }
 )
 
@@ -131,6 +131,23 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+def _format_config_value(value: str | None) -> str:
+    """Encode a set_config_key value as an MQTT payload.
+
+    Numbers, booleans and JSON null are published unquoted. Other strings are
+    JSON-quoted so the charger treats them as strings.
+    """
+    if value is None or value.lower() in ("null", "none"):
+        return "null"
+    if value.isnumeric():
+        return value
+    if value in ("true", "True"):
+        return "true"
+    if value in ("false", "False"):
+        return "false"
+    return f'"{value}"'
+
+
 def _entry_for_device(hass: HomeAssistant, device_id: str) -> ConfigEntry | None:
     device = dr.async_get(hass).async_get(device_id)
     if device is None:
@@ -159,15 +176,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             return
 
         key = call.data[ATTR_KEY]
-        value = call.data[ATTR_VALUE]
-
-        if not value.isnumeric():
-            if value in ["true", "True"]:
-                value = "true"
-            elif value in ["false", "False"]:
-                value = "false"
-            else:
-                value = f'"{value}"'
+        value = _format_config_value(call.data[ATTR_VALUE])
 
         await mqtt.async_publish(hass, f"{entry.data[CONF_TOPIC]}/{key}/set", value)
 

--- a/custom_components/goecharger_mqtt/services.yaml
+++ b/custom_components/goecharger_mqtt/services.yaml
@@ -128,7 +128,9 @@ set_config_key:
             - wifis
     value:
       name: Value
-      description: The new value to set for this config parameter.
+      description: >
+        The new value. Use "null" to clear nullable keys such as trx
+        (transaction) or dwo (energy limit).
       example: "go-e"
       required: true
       selector:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -223,6 +223,57 @@ async def test_service_bool_false(hass: HomeAssistant) -> None:
     mock_pub.assert_called_once_with(hass, "go-eCharger/072246/bac/set", "false")
 
 
+async def test_service_null_string_is_unquoted(hass: HomeAssistant) -> None:
+    """The string 'null' is published as JSON null, not the quoted string "null"."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "trx", "value": "null"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/trx/set", "null")
+
+
+async def test_service_none_string_is_unquoted(hass: HomeAssistant) -> None:
+    """The string 'none' is published as JSON null (select option name for trx)."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "trx", "value": "none"},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/trx/set", "null")
+
+
+async def test_service_yaml_null_is_unquoted(hass: HomeAssistant) -> None:
+    """YAML null (Python None) is published as JSON null."""
+    device = await _register_service_and_device(hass, "go-eCharger/072246")
+
+    with patch(
+        "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+    ) as mock_pub:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_config_key",
+            {"device_id": device.id, "key": "trx", "value": None},
+            blocking=True,
+        )
+
+    mock_pub.assert_called_once_with(hass, "go-eCharger/072246/trx/set", "null")
+
+
 # ---------------------------------------------------------------------------
 # set_config_key service — topic variants
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Clearing nullable config keys such as `trx` (transaction) via `goecharger_mqtt.set_config_key` failed. The charger expects JSON `null`, but the service JSON-quoted any non-numeric, non-boolean value. Passing `value: "null"` therefore published the string `"null"`, and the charger rejected it with `value must be null or uint8_t "null"`.

The Transaction **select entity** already works: it reverse-maps the `none` option through `legacy_options` and publishes unquoted `null`. The dedicated "Clear energy limit" button does the same for `dwo`. The service did not.

The README was also still documenting `serial_number` for this service after it was switched to `device_id`.

## Changes

- Extract `_format_config_value()` so `null` / `none` / YAML `null` are published as unquoted JSON `null` (same treatment as `true`/`false`).
- Accept YAML `null` (`None`) in the service schema in addition to strings.
- Update README: `device_id` instead of `serial_number`, plus a short note on value encoding (including how to clear `trx`).
- Update `services.yaml` to mention using `"null"` for nullable keys such as `trx` and `dwo`.
- Add tests covering `"null"`, `"none"`, and Python `None`.

## Test plan

- [x] New tests in `tests/test_init.py` assert MQTT payload `null` (unquoted) for `value: "null"`, `"none"`, and `None`
- [ ] Existing `set_config_key` tests still pass (numeric, quoted string, bool true/false)
- [ ] Call `goecharger_mqtt.set_config_key` with `key: trx` and `value: "null"` against a charger and confirm `/trx/result` succeeds (same outcome as selecting "None" on the Transaction entity)